### PR TITLE
Tweak .errorbox padding on smaller screens

### DIFF
--- a/app/modules/general/scss/_errors.scss
+++ b/app/modules/general/scss/_errors.scss
@@ -12,14 +12,14 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $smallscreen) {
+  @media screen and (max-width: $verysmallscreen) {
     .errorBox{
       padding: 1em;
     }
   }
 
   /*Large screens*/
-  @media screen and (min-width: $smallscreen) {
+  @media screen and (min-width: $verysmallscreen) {
     .errorBox{
       padding: 4em;
     }


### PR DESCRIPTION
`.errorbox` keeps the `padding: 2em 4em;` down to width 350px(1200px before).

Could not find any long error that broke this.