### PR TITLE
Fix for ctrl+click on map (issue #82)

### DIFF
--- a/app/lib/utils.coffee
+++ b/app/lib/utils.coffee
@@ -84,7 +84,7 @@ module.exports = (Backbone, _, $, app, window)->
 
   # anchor with a href are opened out of the current window
   # when the ctrlKey is pressed: the normal action should thus be prevented
-  isOpenedOutside: (e)-> e.ctrlKey
+  isOpenedOutside: (e)-> e.ctrlKey or e.metaKey
 
   noop: ->
 

--- a/app/modules/general/lib/smart_prevent_default.coffee
+++ b/app/modules/general/lib/smart_prevent_default.coffee
@@ -13,6 +13,9 @@ module.exports = (e)->
   # `unless _.isOpenedOutside(e) then handler()`
   if _.isOpenedOutside(e) then return
 
+  # If there is no href on current target, then the default
+  # behaviour is to do nothing.
+  # Therefore, there is no reason to preventDefault.
   if e.currentTarget?
     $link = $(e.currentTarget)
     # Get the href; stop processing if there isn't one

--- a/app/modules/map/lib/map.coffee
+++ b/app/modules/map/lib/map.coffee
@@ -78,4 +78,6 @@ showUserInventory = (user, e)->
 formatLeafletEvent = (e)->
   e.which = e.originalEvent.which
   e.preventDefault = e.originalEvent.preventDefault.bind(e.originalEvent)
+  e.ctrlKey = e.originalEvent.ctrlKey
+  e.metaKey = e.originalEvent.metaKey
   return e


### PR DESCRIPTION
This is a fix for issue #82 to get the ctrl/cmd map to work. Also added metaKey to work on mac...