### PR TITLE
Added ordinal serie display and consistency with wikidata

### DIFF
--- a/app/modules/entities/views/templates/work_claims.hbs
+++ b/app/modules/entities/views/templates/work_claims.hbs
@@ -1,6 +1,7 @@
 <div class='wiki-attributes'>
   <p class="claims">
     {{claim claims 'wdt:P179' true}} {{!-- serie --}}
+    {{claim claims 'wdt:P1545'}} {{!-- serie ordinal --}}
     {{stringClaim claims 'wdt:P1476'}} {{!-- original title --}}
     {{stringClaim claims 'wdt:P1680'}} {{!-- subtitle --}}
     {{claim claims 'wdt:P364'}} {{!-- original language --}}

--- a/app/modules/inventory/models/item.coffee
+++ b/app/modules/inventory/models/item.coffee
@@ -96,7 +96,7 @@ module.exports = Filterable.extend
     attrs.picture = @getPicture()
     attrs.authors = @get 'snapshot.entity:authors'
     attrs.series = @get 'snapshot.entity:series'
-    attrs.rank = @get 'snapshot.entity:rank'
+    attrs.ordinal = @get 'snapshot.entity:ordinal'
 
     return attrs
 

--- a/app/modules/inventory/views/templates/item_figure.hbs
+++ b/app/modules/inventory/views/templates/item_figure.hbs
@@ -16,7 +16,7 @@
     {{/if}}
     <h3 class="title">
       {{title}}
-      {{#if rank}}<san class="rank" title="{{i18n 'rank'}}">({{rank}})</span>{{/if}}
+      {{#if ordinal}} - <span class="ordinal" title="{{i18n 'ordinal'}}">({{ordinal}})</span>{{/if}}
     </h3>
     {{#if authors}}
       <hr>


### PR DESCRIPTION
I renamed the "rank" property to "ordinal" to stay consistent with the wikidata definition and added the information on the work display