### PR TITLE
124s isbn search

### DIFF
--- a/app/modules/entities/entities.coffee
+++ b/app/modules/entities/entities.coffee
@@ -60,6 +60,12 @@ API =
     .tap app.navigateFromModel
     .then @getEntityViewByType.bind(@, refresh)
     .then app.layout.main.show.bind(app.layout.main)
+    .catch (err)->
+      # Redirect unknown entity types to their subject pages
+      if err.message is 'unknown entity type'
+        return showClaimEntities "wdt:P921-#{uri}"
+      else
+        throw err
     .catch handleMissingEntity(uri)
 
   getEntityViewByType: (refresh, entity)->

--- a/app/modules/search/lib/find_uri.coffee
+++ b/app/modules/search/lib/find_uri.coffee
@@ -1,0 +1,10 @@
+wdk = require 'lib/wikidata-sdk'
+isbn_ = require 'lib/isbn'
+
+module.exports = (text)->
+  text = text.trim()
+  if _.isEntityUri text then return text
+  if wdk.isWikidataItemId(text) then return 'wd:' + text
+  if _.isInvEntityId(text) then return 'inv:' + text
+  if isbn_.looksLikeAnIsbn(text) then return 'isbn:' + isbn_.normalizeIsbn(text)
+  return

--- a/app/modules/search/scss/_live_search.scss
+++ b/app/modules/search/scss/_live_search.scss
@@ -17,6 +17,11 @@
   .results{
     max-height: 60vh;
     overflow: auto;
+    &.loading{
+      @include display-flex(row, center, center);
+      height: 2.5em;
+      background-color: $light-grey;
+    }
   }
   &:not(.results-0){
     .no-result{

--- a/app/modules/search/search.coffee
+++ b/app/modules/search/search.coffee
@@ -27,10 +27,7 @@ API.search = (query, refresh)->
     app.execute 'show:add:layout:search'
     return
 
-  # If the query text is a URI, show the associated entity page
-  # as it doesn't make sense to search for an entity we have already found
-  uri = findUri query
-  if uri? then return app.execute 'show:entity', uri, null, { refresh }
+  if showEntityPageIfUri(query, refresh) then return
 
   # Else, show the normal search layout
   app.layout.main.show new SearchLayout { query, refresh }
@@ -44,6 +41,9 @@ API.searchFromQueryString = (querystring)->
   refresh = _.parseBooleanString refresh
   # Replacing "+" added that the browser search might have added
   q = q.replace /\+/g, ' '
+
+  if showEntityPageIfUri(q, refresh) then return
+
   # Forwarding to the top bar live search instead of directly calling API.search
   # as the live search is way faster, and from their the full search,
   # if needed, is one click away
@@ -52,3 +52,13 @@ API.searchFromQueryString = (querystring)->
     # Show the add layout at its search tab in the background, so that clicking
     # out of the live search doesn't result in a blank page
     showFallbackLayout: app.Execute 'show:add:layout:search'
+
+showEntityPageIfUri = (query, refresh)->
+  # If the query text is a URI, show the associated entity page
+  # as it doesn't make sense to search for an entity we have already found
+  uri = findUri query
+  if uri?
+    app.execute 'show:entity', uri, null, { refresh }
+    return true
+  else
+    return false

--- a/app/modules/search/search.coffee
+++ b/app/modules/search/search.coffee
@@ -1,6 +1,7 @@
 Searches = require './collections/searches'
 SearchLayout = require './views/search'
 error_ = require 'lib/error'
+findUri = require './lib/find_uri'
 
 module.exports =
   define: (module, app, Backbone, Marionette, $, _)->
@@ -26,6 +27,12 @@ API.search = (query, refresh)->
     app.execute 'show:add:layout:search'
     return
 
+  # If the query text is a URI, show the associated entity page
+  # as it doesn't make sense to search for an entity we have already found
+  uri = findUri query
+  if uri? then return app.execute 'show:entity', uri, null, { refresh }
+
+  # Else, show the normal search layout
   app.layout.main.show new SearchLayout { query, refresh }
 
   encodedQuery = _.fixedEncodeURIComponent query

--- a/app/modules/search/views/live_search.coffee
+++ b/app/modules/search/views/live_search.coffee
@@ -10,8 +10,7 @@
 
 Results = Backbone.Collection.extend { model: require('../models/result') }
 wikidataSearch = require 'modules/entities/lib/sources/wikidata_search'
-wdk = require 'lib/wikidata-sdk'
-isbn_ = require 'lib/isbn'
+findUri = require '../lib/find_uri'
 spinner = _.icon 'circle-o-notch', 'fa-spin'
 
 module.exports = Marionette.CompositeView.extend
@@ -169,10 +168,3 @@ formatEntity = (entity)->
   # Return a model to prevent having it re-formatted
   # as a Result model, which works from a result object, not an entity
   return new Backbone.Model data
-
-findUri = (text)->
-  if _.isEntityUri text then return text
-  if wdk.isWikidataItemId(text) then return 'wd:' + text
-  if _.isInvEntityId(text) then return 'inv:' + text
-  if isbn_.looksLikeAnIsbn(text) then return 'isbn:' + isbn_.normalizeIsbn(text)
-  return


### PR DESCRIPTION
fixed inventaire/inventaire/issues/124

Main feature: both live_search and search_layout now redirect to the entity page when the query is an entity URI

Ex: https://inventaire/search?q=978-80-7484-078-4