### PR TITLE
Use darker background color for better contrast

### DIFF
--- a/app/modules/general/scss/_general_settings.scss
+++ b/app/modules/general/scss/_general_settings.scss
@@ -24,7 +24,7 @@ html{
 
 body{
   height: auto;
-  background: #f5f5f5;
+  background: $light-grey;
   color: #222;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
I was just scrolling through my inventory looking for books without a cover and noticed I sometimes missed them because I had a hard time distinguishing the actual book "cards" from the background, relying mostly on said covers to see where a book was. I hopped into the dev tools and set the background color to `#eee` and it made quite a difference to me, so thought I'd open a PR about it to see what others feel. Now, I'm not sure 1) if `#eee` would be the right color, 2) if the place I changed it affects some other unforeseen place, and I guess 0) if you actually want this, but that's all things I thought we could discuss here 😊

Edit: Oh, and I didn't test this change, so I'm not sure it'd work. It's the same place I edited in dev tools, but I put the hex in directly there and here I just assumed I could use a SCSS-variable I found in `app/modules/general/scss/_colors.scss`

Current:
![inventaire-now](https://user-images.githubusercontent.com/3090888/66083370-6da0e380-e56c-11e9-9216-763ce5e10bd2.png)

Higher contrast:
![inventaire-dark](https://user-images.githubusercontent.com/3090888/66083375-709bd400-e56c-11e9-8be9-fa43531ffe7c.png)
