### PR TITLE
align delete button in item view with other elements

### DIFF
--- a/app/modules/inventory/scss/_item_show.scss
+++ b/app/modules/inventory/scss/_item_show.scss
@@ -1,10 +1,12 @@
 #itemShowLayout{
-  padding: 0 1em 1em 1em;
+  padding: 0 1em;
   position: relative;
   .one{
   }
   .two{
-    max-width: 30em;
+    margin: 0;
+    max-width: 36em;
+    min-height: 350px;
   }
   a.edition, a.work, .author-preview a, .series-preview a{
     margin: 0.2em 0;
@@ -40,9 +42,9 @@
     font-weight: bold;
   }
   .remove-button{
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    float: right;
+    margin: 1em 0;
+    padding: 0.2em 1em;
     @include shy(0.9);
     .fa{
       font-size: 1.1em;
@@ -51,10 +53,10 @@
       @include tiny-button-padding;
       border-radius: $global-radius;
       background-color: $danger-color;
-      padding: 0.2em 0.4em 0.2em 0.6em;
+      padding: 0.2em 1em;
       color: white;
-      .fa{
-        padding-left: 0.2em;
+      span{
+        padding-left: 0.4em;
       }
     }
   }

--- a/app/modules/inventory/views/item_show_data.coffee
+++ b/app/modules/inventory/views/item_show_data.coffee
@@ -23,16 +23,6 @@ module.exports = ItemLayout.extend
     @alertBoxTarget = '.leftBox .panel'
     @listenTo @model, 'change', @lazyRender
 
-  onShow: ->
-    @setTimeout @preserveMinHeight.bind(@), 200
-
-  # Allows to re-render without provoking a scroll jump because the view
-  # suddenly takes less room vertically
-  preserveMinHeight: ->
-    # Add a margin to take in account details and notes form mode height
-    minHeight = @$el.parent().height() + 30
-    @$el.parent().css 'min-height', minHeight
-
   onRender: ->
     if app.user.loggedIn then @showTransactions()
 

--- a/app/modules/inventory/views/templates/item_show_data.hbs
+++ b/app/modules/inventory/views/templates/item_show_data.hbs
@@ -14,12 +14,12 @@
       {{/unless}}
       {{partial 'inventory:item_visibility_box' this}}
     </div>
+    {{partial 'inventory:item_note' this}}
+    {{partial 'inventory:item_details' this}}
     <a class="remove remove-button shy-label dark-grey">
       <span>{{I18n 'delete'}}</span>
       {{icon 'trash-o'}}
     </a>
-    {{partial 'inventory:item_note' this}}
-    {{partial 'inventory:item_details' this}}
   {{/if}}
 {{/if}}
 <div id="transactions"></div>


### PR DESCRIPTION
also uniformize vertical seperation and margin around
block ".one" and block ".two"

Problem : now `#itemData` element is having a bottom margin way to large (as seen from issue #191  screenshot), this is due to an inline rule inserted on the dom element : `<div id="itemData" class="two" style="min-height: 367px;">`. This rule override any scss rule and should be delete or changed to `350px` to reduce the bottom margin, but i dont really know where this inline rule come from...