### PR TITLE
items_table: move mass-edit actions to dedicated modal

### DIFF
--- a/app/modules/inventory/scss/_item_row.scss
+++ b/app/modules/inventory/scss/_item_row.scss
@@ -50,7 +50,6 @@
     @include display-flex(row, center, flex-start);
     @include bg-hover(white, 5%);
     flex: 1 0 0;
-    // overflow: hidden;
   }
 
   /*Small screens*/

--- a/app/modules/inventory/scss/_items_table.scss
+++ b/app/modules/inventory/scss/_items_table.scss
@@ -1,61 +1,69 @@
 .items-table{
   position: relative;
   background-color: $inventory-nav-grey;
-  #table-header:not(.hidden){
+  #table-actions:not(.hidden){
     @include display-flex(row);
     background-color: $inventory-nav-grey;
+    position: sticky;
+    bottom: 0;
     // Required for unclear reasons to allow .dropdown divs to appear
     // above .item-row elements
     z-index: 1;
-    button, .selector-label{
-      padding: 0.5em 1em;
-      margin: 0 0.5em;
-      text-align: center;
-      @include bg-hover(white);
-      font-weight: bold;
-    }
     button{
-      // Make buttons be of same height as .selector-label p elements
+      text-align: center;
+      font-weight: bold;
       line-height: 1.6em;
     }
-    button.remove:hover{
-      background-color: $danger-color;
-      color: white;
+    #selectAll, #unselectAll{
+      @include bg-hover(white);
+    }
+    #editSelection{
+      @include bg-hover($light-blue);
+      &, .count{
+        color: white;
+      }
     }
   }
+
   .dropdown-label{
     margin-left: 0.5em;
   }
 
-  .disabled{
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  /*Large screens*/
-  @media screen and (min-width: $small-screen) {
-    #table-header:not(.hidden){
-      position: sticky;
-      top: $topbar-height;
+  /*Medium and Large screens*/
+  @media screen and (min-width: 800px) {
+    #table-actions:not(.hidden){
       padding: 0.5em;
+    }
+    button{
+      padding: 0.5em 1em;
+      margin: 0 0.5em;
     }
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
-    #table-header:not(.hidden){
-      overflow: auto;
-      flex-direction: column;
+  @media screen and (max-width: 800px) {
+    #table-actions:not(.hidden){
+      @include shy-border;
       align-items: stretch;
+      flex-wrap: wrap;
+    }
+    #selectAll, #unselectAll, #editSelection{
+      @include radius(0);
       padding: 0.5em 0;
-      > button, > div{
-        margin: 0.5em 0;
-      }
-      .selector-label{
-        margin: 0;
-      }
+    }
+    #selectAll, #unselectAll{
+      // Prefer to `width: 50%` to prevent horizontal scroll
+      flex: 1 0 40%;
+    }
+    #editSelection{
+      // Prefer to `width: 100%` to prevent horizontal scroll
+      flex: 1 0 80%;
+    }
+    #selectAll .count{
+      display: none;
     }
   }
 }
 
 @import 'item_row';
+@import 'items_table_selection_editor';

--- a/app/modules/inventory/scss/_items_table_selection_editor.scss
+++ b/app/modules/inventory/scss/_items_table_selection_editor.scss
@@ -1,0 +1,46 @@
+.items-table-selection-editor{
+  @include display-flex(column, center, center);
+  #selectTransaction, #selectListing, .delete{
+    @include radius;
+  }
+  #selectTransaction, #selectListing{
+    @include bg-hover(#eee);
+  }
+  .delete{
+    @include dangerous-action;
+  }
+  .selector-label{
+    text-align: center;
+    font-weight: bold;
+  }
+  .dropdown-label, .dropdown li{
+    font-size: 1rem;
+  }
+  .dropdown-label{
+    padding: 0.5em;
+  }
+
+  /*Large screens*/
+  @media screen and (min-width: $small-screen) {
+    #selectTransaction, #selectListing, .delete, .dropdown{
+      min-width: 12rem;
+    }
+    #selectTransaction, #selectListing, .delete{
+      padding: 1em;
+      margin: 1em;
+    }
+  }
+  /*Small screens*/
+  @media screen and (max-width: $small-screen) {
+    #selectTransaction, #selectListing, .delete{
+      align-self: stretch;
+    }
+    .dropdown{
+      width: 100%;
+    }
+    #selectTransaction, #selectListing, .delete{
+      padding: 0.5em;
+      margin: 1em 0.5em;
+    }
+  }
+}

--- a/app/modules/inventory/scss/_user_profile.scss
+++ b/app/modules/inventory/scss/_user_profile.scss
@@ -22,7 +22,7 @@
   }
   .profile-buttons{
     @include display-flex(row, center, center);
-    a {
+    a{
       margin: 0 0 1em 1em;
     }
     flex: 0 0 auto;

--- a/app/modules/inventory/views/items_table_selection_editor.coffee
+++ b/app/modules/inventory/views/items_table_selection_editor.coffee
@@ -1,0 +1,43 @@
+{ data: transactionsData } = require '../lib/transactions_data'
+
+module.exports = Marionette.ItemView.extend
+  className: 'items-table-selection-editor'
+  template: require './templates/items_table_selection_editor'
+  events:
+    'click .transaction-option': 'setTransaction'
+    'click .listing-option': 'setListing'
+    'click .delete': 'deleteItems'
+
+  initialize: ->
+    { @getSelectedModelsAndIds, @selectedIds } = @options
+
+  serializeData: ->
+    selectedIdsCount: @selectedIds.length
+    transactions: transactionsData
+    listings: app.user.listings()
+
+  onShow: ->
+    app.execute 'modal:open'
+
+  setTransaction: (e)-> @updateItems e, 'transaction'
+
+  setListing: (e)-> @updateItems e, 'listing'
+
+  updateItems: (e, attribute)->
+    value = e.currentTarget.id
+    { selectedModelsAndIds } = @getSelectedModelsAndIds()
+    app.request 'items:update', { items: selectedModelsAndIds, attribute, value }
+    app.execute 'modal:close'
+
+  deleteItems: ->
+    if @selectedIds.length is 0 then return
+
+    { selectedModelsAndIds, selectedModels, selectedIds } = @getSelectedModelsAndIds()
+
+    app.request 'items:delete',
+      items: selectedModelsAndIds
+      next: @options.afterItemsDelete
+
+  afterItemsDelete: ->
+    app.execute 'modal:close'
+    @options.afterItemsDelete()

--- a/app/modules/inventory/views/templates/items_table.hbs
+++ b/app/modules/inventory/views/templates/items_table.hbs
@@ -1,38 +1,21 @@
-<div id="table-header" class="{{#unless isMainUser}}hidden{{/unless}}">
+<ul id="itemsRows"></ul>
+
+<div id="table-actions" class="{{#unless isMainUser}}hidden{{/unless}}">
   <button id="selectAll">
     {{icon 'check-square-o'}}
-    {{I18n 'select all'}}
+    <span class="button-label">{{I18n 'select all'}}</span>
     <span class="count">({{itemsCount}})</span>
   </button>
-  <button id="unselectAll" class="hidden">{{icon 'square-o'}}<span>{{I18n 'unselect all'}}</span></button>
-
-  <div id="selectTransaction" class="has-dropdown selector hidden">
-    <p class="selector-label">{{I18n 'transaction'}} {{icon 'caret-down'}}</p>
-    <ul class="dropdown">
-      <li class="dropdown-label capitalized">{{I18n 'available for'}}:</li>
-      {{#each transactions}}
-        <li><a id="{{id}}" class="transaction-option">{{icon icon}} {{I18n label}}</a></li>
-      {{/each}}
-    </ul>
-  </div>
-
-  <div id="selectListing" class="has-dropdown selector hidden">
-    <p class="selector-label">{{I18n 'listing'}} {{icon 'caret-down'}}</p>
-    <ul class="dropdown">
-      <li class="dropdown-label capitalized">{{I18n 'visible by'}}:</li>
-      {{#each listings}}
-        <li><a id="{{id}}" class="listing-option">{{icon icon}} {{I18n label}}</a></li>
-      {{/each}}
-    </ul>
-  </div>
-
-  <button class="delete hidden">
-    <span>{{I18n 'delete'}}</span>
-    {{icon 'trash-o'}}
+  <button id="unselectAll" class="hidden">
+    {{icon 'square-o'}}
+    <span class="button-label">{{I18n 'unselect all'}}</span>
+  </button>
+  <button id="editSelection" class="hidden">
+    {{icon 'pencil'}}
+    <span class="button-label">{{I18n 'edit selection'}}</span>
+    <span class="selectionCounter count"></span>
   </button>
 </div>
-
-<ul id="itemsRows"></ul>
 
 <div class="fetchMore">
   <span class="loading"></span>

--- a/app/modules/inventory/views/templates/items_table_selection_editor.hbs
+++ b/app/modules/inventory/views/templates/items_table_selection_editor.hbs
@@ -1,0 +1,26 @@
+<h3>{{{I18n 'editing_selected_items' smart_count=selectedIdsCount}}}</h3>
+
+<div id="selectTransaction" class="has-dropdown selector">
+  <p class="selector-label">{{I18n 'transaction'}} {{icon 'caret-down'}}</p>
+  <ul class="dropdown">
+    <li class="dropdown-label capitalized">{{I18n 'available for'}}:</li>
+    {{#each transactions}}
+      <li><a id="{{id}}" class="transaction-option">{{icon icon}} {{I18n label}}</a></li>
+    {{/each}}
+  </ul>
+</div>
+
+<div id="selectListing" class="has-dropdown selector">
+  <p class="selector-label">{{I18n 'listing'}} {{icon 'caret-down'}}</p>
+  <ul class="dropdown">
+    <li class="dropdown-label capitalized">{{I18n 'visible by'}}:</li>
+    {{#each listings}}
+      <li><a id="{{id}}" class="listing-option">{{icon icon}} {{I18n label}}</a></li>
+    {{/each}}
+  </ul>
+</div>
+
+<button class="delete">
+  {{icon 'trash-o'}}
+  <span>{{I18n 'delete'}}</span>
+</button>


### PR DESCRIPTION
- removing the need for a confirmation for edits other than deletion
- freeing space on small screens

also moving the `#table-actions` bar (formerly `#table-header`) down to be a bottom sticky bar

## Before
<p>
<img src="https://user-images.githubusercontent.com/1596934/75796697-56ad2a00-5d74-11ea-831a-002ae60d5f45.png">
<img src="https://user-images.githubusercontent.com/1596934/75796699-5745c080-5d74-11ea-8ebb-13d1cc3acd28.png">
</p>

## After
<p>
<img src="https://user-images.githubusercontent.com/1596934/75796720-5dd43800-5d74-11ea-8b1e-32a7b499c4d2.jpg">
<img src="https://user-images.githubusercontent.com/1596934/75796723-5e6cce80-5d74-11ea-9d96-0f61aa396a40.jpg">
</p>
