### PR TITLE
enable cursor select entity data in edition modal

### DIFF
--- a/app/modules/inventory/scss/_item_show.scss
+++ b/app/modules/inventory/scss/_item_show.scss
@@ -8,11 +8,11 @@
     max-width: 36em;
     min-height: 350px;
   }
-  a.edition, a.work, .author-preview a, .series-preview a{
+  .edition, .work, .author-preview a, .series-preview a{
     margin: 0.2em 0;
     @include bg-hover(#f3f3f3);
   }
-  a.edition, a.work{
+  .edition, .work{
     @include display-flex(column, center, center);
     margin-bottom: 2em;
   }

--- a/app/modules/inventory/views/templates/item_show.hbs
+++ b/app/modules/inventory/views/templates/item_show.hbs
@@ -9,25 +9,29 @@
       <span class="section-label">{{I18n 'work'}}</span>
     {{/if}}
 
-    <a class="showEntity {{entityType}}" href="{{entityData.pathname}}">
+    <p class="{{entityType}}">
       {{#if snapshot.entity:image}}
+        <a class="showEntity" href="{{entityData.pathname}}">
+
         <img class="entity-image" src="{{imgSrc snapshot.entity:image 400}}">
+        </a>
+
       {{/if}}
-      <span class="title">{{snapshot.entity:title}}</span><br>
-      <span class="subtitle">{{snapshot.entity:subtitle}}</span><br>
+      <a class="showEntity title" href="{{entityData.pathname}}">{{snapshot.entity:title}}</a><br>
+      <a class="showEntity subtitle">{{snapshot.entity:subtitle}}</a><br>
       {{#if entityIsEdition}}{{#if entityData.claims.wdt:P212}}
-        <span class="identifier">ISBN: {{entityData.claims.wdt:P212}}</span>
+        <a class="showEntity identifier">ISBN: {{entityData.claims.wdt:P212}}</a>
       {{/if}}{{/if}}
-    </a>
+    <p>
 
     {{#if entityIsEdition}}
       <span class="section-label">
       {{#if entityData.isCompositeEdition}}{{I18n 'works'}}{{else}}{{I18n 'work'}}{{/if}}
       </span>
       {{#each works}}
-        <a class="work showEntity" href="{{pathname}}">
-          <span class="related-entity-label">{{label}}</span>
-        </a>
+        <p class="work">
+          <a class="related-entity-label showEntity" href="{{pathname}}">{{label}}</a>
+        </p>
       {{/each}}
     {{else}}
       {{#if mainUserIsOwner}}


### PR DESCRIPTION
As the item modal is the quickest way to access an isbn in my inventory, I would like to select the ISBN text (and title etc) to copy paste it wherever i want. 
![Sélection_019](https://user-images.githubusercontent.com/5363918/76108470-940ef300-5fd2-11ea-9a2d-bc5589c92c1e.png)
This solution enable text selection at the price of a smaller clickable area (only the text and the image)