### PR TITLE
add support for local publisher collections entities

### DIFF
--- a/app/api/entities.coffee
+++ b/app/api/entities.coffee
@@ -17,6 +17,7 @@ module.exports =
 
   authorWorks: CustomQuery 'author-works'
   serieParts: CustomQuery 'serie-parts'
+  publisherPublications: CustomQuery 'publisher-publications'
 
   activity: (period)-> action 'activity', { period }
   changes: action 'changes'

--- a/app/lib/handlebars_helpers/claims_helpers.coffee
+++ b/app/lib/handlebars_helpers/claims_helpers.coffee
@@ -30,6 +30,7 @@ propertyWithSpecialLayout = [
   'wdt:P179' # serie
   'wdt:P629' # work
   'wdt:P123' # publisher
+  'wdt:P195' # collection
   'wdt:P155' # preceded by (work)
   'wdt:P156' # followed by (work)
   'wdt:P737' # influenced by (human)

--- a/app/modules/entities/collections/paginated_entities.coffee
+++ b/app/modules/entities/collections/paginated_entities.coffee
@@ -2,19 +2,26 @@ Entities = require './entities'
 
 module.exports = Entities.extend
   initialize: (models, options = {})->
+    { uris } = options
+    unless uris? then throw new Error 'expected uris'
+    # Clone the array as it will be mutated
+    @allUris = uris.slice(0)
     # At the begining, all URIs are unfetched URIs
-    @remainingUris = @allUris = options.uris
-    unless @remainingUris? then throw new Error 'expected uris'
-    @totalLength = options.uris.length
+    @remainingUris = @allUris
+    @totalLength = uris.length
     @fetchedUris = []
     { @refresh, @defaultType, @parentContext } = options
     @typesAllowlist ?= options.typesAllowlist
 
-  fetchMore: (amount)->
-    urisToFetch = _.difference @remainingUris[0...amount], @fetchedUris
+  resetFromUris: (uris)->
+    @remainingUris = uris
+    @reset()
+    @fetchMore()
+
+  fetchMore: (amount = 10)->
+    urisToFetch = @remainingUris.splice(0, amount)
     fetchedUrisBefore = @fetchedUris
-    @fetchedUris = @fetchedUris.concat urisToFetch
-    @remainingUris = @remainingUris[amount..-1]
+    @fetchedUris = @fetchedUris.concat(urisToFetch)
 
     rollback = (err)=>
       @remainingUris = urisToFetch.concat @remainingUris

--- a/app/modules/entities/lib/editor/properties_per_type.coffee
+++ b/app/modules/entities/lib/editor/properties_per_type.coffee
@@ -80,5 +80,5 @@ module.exports =
     'wdt:P1476': { customLabel: 'title' }
     'wdt:P1680': {} # subtitle
     'wdt:P123': {} # publisher
-    'wdt:P98': { customLabel: 'editor'}
+    'wdt:P98': { customLabel: 'collection editor'}
     'wdt:P856': {} # official website

--- a/app/modules/entities/lib/editor/properties_per_type.coffee
+++ b/app/modules/entities/lib/editor/properties_per_type.coffee
@@ -77,7 +77,7 @@ module.exports =
     'wdt:P3035': {} # ISBN publisher
 
   collection:
-    'wdt:P1476': { customLabel: 'title' }
+    'wdt:P1476': { customLabel: 'collection title' }
     'wdt:P1680': {} # subtitle
     'wdt:P123': {} # publisher
     'wdt:P98': { customLabel: 'collection editor'}

--- a/app/modules/entities/lib/editor/properties_per_type.coffee
+++ b/app/modules/entities/lib/editor/properties_per_type.coffee
@@ -32,7 +32,6 @@ module.exports =
     'wdt:P629': {} # edition or translation of
     'wdt:P1476': { customLabel: 'edition title' }
     'wdt:P1680': { customLabel: 'edition subtitle' }
-    'wdt:P123': {} # publisher
     'wdt:P407': { customLabel: 'edition language' }
     'invp:P2': { customLabel: 'cover' }
     # 'wdt:P31': {} # P31: instance of (=> edition aliases?)
@@ -40,11 +39,14 @@ module.exports =
     'wdt:P212': {} # ISBN-13
     'wdt:P957': {} # ISBN-10
     'wdt:P577': {} # publication date
+    'wdt:P123': {} # publisher
+    'wdt:P195': {} # collection
+    'wdt:P98': { customLabel: 'editor'}
     'wdt:P655': {} # translator
     'wdt:P2679': {} # author of foreword
     'wdt:P2680': {} # author of afterword
     'wdt:P1104': {} # number of pages
-    'wdt:P2635': {} # number of volumes
+    'wdt:P2635': { customLabel: 'number of volumes' }
 
   human:
     'wdt:P1412': {} # languages of expression
@@ -64,6 +66,7 @@ module.exports =
   serie: _.omit work, [ 'wdt:P179', 'wdt:P1545', 'wdt:P747' ]
 
   publisher:
+    'wdt:P856': {} # official website
     'wdt:P112': {} # founded by
     # Problematic to only autocomplete on humans as it is likely to be an organization
     # see https://github.com/inventaire/inventaire/issues/295
@@ -72,4 +75,10 @@ module.exports =
     'wdt:P576': { customLabel: 'date of dissolution' } # inception
     # Maybe, ISBN publisher prefix shouldn't be displayed but only used for administration(?)
     'wdt:P3035': {} # ISBN publisher
+
+  collection:
+    'wdt:P1476': { customLabel: 'title' }
+    'wdt:P1680': {} # subtitle
+    'wdt:P123': {} # publisher
+    'wdt:P98': { customLabel: 'editor'}
     'wdt:P856': {} # official website

--- a/app/modules/entities/lib/editor/properties_per_type.coffee
+++ b/app/modules/entities/lib/editor/properties_per_type.coffee
@@ -80,6 +80,5 @@ module.exports =
     'wdt:P1476': { customLabel: 'collection title' }
     'wdt:P1680': {} # subtitle
     'wdt:P123': {} # publisher
-    'wdt:P98': { customLabel: 'collection editor'}
     'wdt:P921': {} # main subject
     'wdt:P856': {} # official website

--- a/app/modules/entities/lib/editor/properties_per_type.coffee
+++ b/app/modules/entities/lib/editor/properties_per_type.coffee
@@ -81,4 +81,5 @@ module.exports =
     'wdt:P1680': {} # subtitle
     'wdt:P123': {} # publisher
     'wdt:P98': { customLabel: 'collection editor'}
+    'wdt:P921': {} # main subject
     'wdt:P856': {} # official website

--- a/app/modules/entities/lib/entity_draft_model.coffee
+++ b/app/modules/entities/lib/entity_draft_model.coffee
@@ -60,6 +60,7 @@ module.exports =
           labels: @get 'labels'
           claims: @get 'claims'
       fetchSubEntities: Entity::fetchSubEntities
+      fetchSubEntitiesUris: Entity::fetchSubEntitiesUris
 
       # Methods required by app.navigateFromModel
       updateMetadata: -> { title: label or _.I18n('new entity') }

--- a/app/modules/entities/lib/entity_draft_model.coffee
+++ b/app/modules/entities/lib/entity_draft_model.coffee
@@ -10,13 +10,15 @@ typeDefaultP31 =
   serie: 'wd:Q277759'
   edition: 'wd:Q3331189'
   publisher: 'wd:Q2085381'
+  collection: 'wd:Q20655472'
 
 propertiesShortlists =
   human: [ 'wdt:P1412' ]
   work: [ 'wdt:P50' ]
   serie: [ 'wdt:P50' ]
   edition: [ 'invp:P2', 'wdt:P407', 'wdt:P1476', 'wdt:P1680', 'wdt:P577', 'wdt:P123' ]
-  publisher: [ 'wdt:P856' ]
+  publisher: [ 'wdt:P856', 'wdt:P112', 'wdt:P571', 'wdt:P576' ]
+  collection: [ 'wdt:P1476', 'wdt:P123', 'wdt:P98', 'wdt:P856' ]
 
 module.exports =
   create: (options)->

--- a/app/modules/entities/lib/entity_draft_model.coffee
+++ b/app/modules/entities/lib/entity_draft_model.coffee
@@ -16,7 +16,7 @@ propertiesShortlists =
   human: [ 'wdt:P1412' ]
   work: [ 'wdt:P50' ]
   serie: [ 'wdt:P50' ]
-  edition: [ 'invp:P2', 'wdt:P407', 'wdt:P1476', 'wdt:P1680', 'wdt:P577', 'wdt:P123' ]
+  edition: [ 'wdt:P629', 'wdt:P1476', 'wdt:P1680', 'wdt:P123', 'invp:P2', 'wdt:P407', 'wdt:P577' ]
   publisher: [ 'wdt:P856', 'wdt:P112', 'wdt:P571', 'wdt:P576' ]
   collection: [ 'wdt:P1476', 'wdt:P123', 'wdt:P98', 'wdt:P856' ]
 

--- a/app/modules/entities/lib/get_entity_view_by_type.coffee
+++ b/app/modules/entities/lib/get_entity_view_by_type.coffee
@@ -4,6 +4,7 @@ entityViewByType =
   work: require '../views/work_layout'
   publisher: require '../views/publisher_layout'
   article: require '../views/article_li'
+  collection: require '../views/collection_layout'
 
 EditionLayout = require '../views/edition_layout'
 ClaimLayout = require '../views/claim_layout'

--- a/app/modules/entities/lib/properties.coffee
+++ b/app/modules/entities/lib/properties.coffee
@@ -31,10 +31,6 @@ addProp 'wdt:P747', 'fixed-entity', null, true, false
 
 ## edition
 addProp 'wdt:P629', 'entity', 'works', true, true
-# title
-addProp 'wdt:P1476', 'string', null, false, null
-# subtitle
-addProp 'wdt:P1680', 'string', null, false, null
 # image
 addProp 'invp:P2', 'image', null, false, null
 # language
@@ -43,10 +39,8 @@ addProp 'wdt:P407', 'entity', 'languages', true, null
 addProp 'wdt:P212', 'fixed-string', null, false, null
 # isbn 10
 addProp 'wdt:P957', 'fixed-string', null, false, null
-# publisher
-addProp 'wdt:P123', 'entity', 'publishers', false, true
 # collection
-addProp 'wdt:P195', 'entity', 'collections', false, false
+addProp 'wdt:P195', 'entity', 'collections', false, true
 # date of publication
 addProp 'wdt:P577', 'simple-day', null, false, null
 # translator
@@ -59,6 +53,16 @@ addProp 'wdt:P2680', 'entity', 'humans', true, true
 addProp 'wdt:P1104', 'positive-integer', null, false, null
 # number of volumes
 addProp 'wdt:P2635', 'positive-integer', null, false, null
+
+## edition and collection
+# editor
+addProp 'wdt:P98', 'entity', 'humans', true, true
+# publisher
+addProp 'wdt:P123', 'entity', 'publishers', true, true
+# title
+addProp 'wdt:P1476', 'string', null, false, null
+# subtitle
+addProp 'wdt:P1680', 'string', null, false, null
 
 ## human
 # date of birth
@@ -82,9 +86,6 @@ addProp 'wdt:P2397', 'string', null, false, null
 # Mastodon address
 addProp 'wdt:P4033', 'string', null, false, null
 
-## work and human
-addProp 'wdt:P856', 'string', null, false, null
-
 ## publisher
 # founded by
 addProp 'wdt:P112', 'entity', 'humans', false, null
@@ -98,3 +99,7 @@ addProp 'wdt:P571', 'simple-day', 'inception', false, null
 addProp 'wdt:P576', 'simple-day', 'inception', false, null
 # ISBN publisher
 addProp 'wdt:P3035', 'string', null, false, null
+
+## all
+# official website
+addProp 'wdt:P856', 'string', null, false, null

--- a/app/modules/entities/lib/properties.coffee
+++ b/app/modules/entities/lib/properties.coffee
@@ -55,8 +55,6 @@ addProp 'wdt:P1104', 'positive-integer', null, false, null
 addProp 'wdt:P2635', 'positive-integer', null, false, null
 
 ## edition and collection
-# editor
-addProp 'wdt:P98', 'entity', 'humans', true, true
 # publisher
 addProp 'wdt:P123', 'entity', 'publishers', true, true
 # title

--- a/app/modules/entities/lib/search/entities_uris_results.coffee
+++ b/app/modules/entities/lib/search/entities_uris_results.coffee
@@ -15,7 +15,7 @@ module.exports =
   getEntityUri: getEntityUri
   prepareSearchResult: (model)->
     [ prefix, id ] = model.get('uri').split(':')
-    data = model.pick [ 'uri', 'labels', 'aliases', 'descriptions' ]
+    data = model.pick [ 'uri', 'label', 'labels', 'aliases', 'descriptions' ]
     data.id = id
     searchResult = new SearchResult data
     searchResult.fieldMatch = customFieldMatch

--- a/app/modules/entities/lib/search/type_search.coffee
+++ b/app/modules/entities/lib/search/type_search.coffee
@@ -4,6 +4,7 @@ searchType = require './search_type'
 languageSearch = require './language_search'
 { getEntityUri, prepareSearchResult } = require './entities_uris_results'
 error_ = require 'lib/error'
+{ pluralize } = require '../types/type_key'
 
 module.exports = (type, input, limit, offset)->
   uri = getEntityUri input
@@ -33,6 +34,8 @@ searchByEntityUri = (uri, type)->
       throw error_.new 'invalid entity type', 400, model
 
 getSearchTypeFn = (type)->
+  # if type.slice(-1)[0] isnt 's' then type += 's'
+  type = pluralize type
   # the searchType function should take a input string
   # and return an array of results
   switch type

--- a/app/modules/entities/lib/types/collection.coffee
+++ b/app/modules/entities/lib/types/collection.coffee
@@ -17,3 +17,10 @@ specificMethods =
 
   onClaimsChange: (property, oldValue, newValue)->
     @setClaimsBasedAttributes()
+
+  getChildrenCandidatesUris: ->
+    publishersUris = @get 'claims.wdt:P123'
+    app.request 'get:entities:models', { uris: publishersUris }
+    .then (models)->
+      Promise.all _.invoke(models, 'initPublisherPublications')
+      .then -> _.flatten _.pluck(models, 'isolatedEditionsUris')

--- a/app/modules/entities/lib/types/collection.coffee
+++ b/app/modules/entities/lib/types/collection.coffee
@@ -1,0 +1,19 @@
+module.exports = ->
+  _.extend @, specificMethods
+  @childrenClaimProperty = 'wdt:P195'
+  @subentitiesName = 'editions'
+  @setClaimsBasedAttributes()
+  @on 'change:claims', @onClaimsChange.bind(@)
+
+specificMethods =
+  setLabelFromTitle: ->
+    # Take the label from the monolingual title property
+    title = @get('claims.wdt:P1476.0')
+    # inv collections will always have a title, but not the wikidata ones
+    if title? then @set 'label', title
+
+  setClaimsBasedAttributes: ->
+    @setLabelFromTitle()
+
+  onClaimsChange: (property, oldValue, newValue)->
+    @setClaimsBasedAttributes()

--- a/app/modules/entities/lib/types/publisher.coffee
+++ b/app/modules/entities/lib/types/publisher.coffee
@@ -8,11 +8,6 @@ module.exports = ->
 specificMethods =
   beforeSubEntitiesAdd: filterOutWdEditions
 
-  fetchPublisherPublications: (refresh)->
-    if not refresh and @waitForPublicationsData? then return @waitForPublicationsData
-    uri = @get 'uri'
-    @waitForPublicationsData = _.preq.get app.API.entities.publisherPublications(uri, refresh)
-
   initPublisherPublications: (refresh)->
     refresh = @getRefresh refresh
     if not refresh and @waitForPublications? then return @waitForPublications
@@ -20,10 +15,14 @@ specificMethods =
     @waitForPublications = @fetchPublisherPublications refresh
       .then @initPublicationsCollections.bind(@)
 
+  fetchPublisherPublications: (refresh)->
+    if not refresh and @waitForPublicationsData? then return @waitForPublicationsData
+    uri = @get 'uri'
+    @waitForPublicationsData = _.preq.get app.API.entities.publisherPublications(uri, refresh)
+
   initPublicationsCollections: (publicationsData)->
     { collections, editions } = publicationsData
     @publisherCollectionsUris = _.pluck(collections, 'uri')
-
     isolatedEditions = editions.filter isntInAKnownCollection(@publisherCollectionsUris)
     @isolatedEditionsUris = _.pluck isolatedEditions, 'uri'
 

--- a/app/modules/entities/lib/types/publisher.coffee
+++ b/app/modules/entities/lib/types/publisher.coffee
@@ -1,5 +1,4 @@
 filterOutWdEditions = require '../filter_out_wd_editions'
-PaginatedEntities = require '../../collections/paginated_entities'
 
 module.exports = ->
   @childrenClaimProperty = 'wdt:P123'
@@ -23,13 +22,10 @@ specificMethods =
 
   initPublicationsCollections: (publicationsData)->
     { collections, editions } = publicationsData
-    collectionsUris = _.pluck(collections, 'uri')
+    @publisherCollectionsUris = _.pluck(collections, 'uri')
 
-    isolatedEditions = editions.filter isntInAKnownCollection(collectionsUris)
-    isolatedEditionsUris = _.pluck isolatedEditions, 'uri'
-
-    @publisherCollections = new PaginatedEntities null, { uris: collectionsUris, defaultType: 'collection' }
-    @isolatedEditions = new PaginatedEntities null, { uris: isolatedEditionsUris, defaultType: 'edition' }
+    isolatedEditions = editions.filter isntInAKnownCollection(@publisherCollectionsUris)
+    @isolatedEditionsUris = _.pluck isolatedEditions, 'uri'
 
 isntInAKnownCollection = (collectionsUris)-> (edition)->
   unless edition.collection? then return true

--- a/app/modules/entities/lib/types/publisher.coffee
+++ b/app/modules/entities/lib/types/publisher.coffee
@@ -1,4 +1,5 @@
 filterOutWdEditions = require '../filter_out_wd_editions'
+PaginatedEntities = require '../../collections/paginated_entities'
 
 module.exports = ->
   @childrenClaimProperty = 'wdt:P123'
@@ -7,3 +8,29 @@ module.exports = ->
 
 specificMethods =
   beforeSubEntitiesAdd: filterOutWdEditions
+
+  fetchPublisherPublications: (refresh)->
+    if not refresh and @waitForPublicationsData? then return @waitForPublicationsData
+    uri = @get 'uri'
+    @waitForPublicationsData = _.preq.get app.API.entities.publisherPublications(uri, refresh)
+
+  initPublisherPublications: (refresh)->
+    refresh = @getRefresh refresh
+    if not refresh and @waitForPublications? then return @waitForPublications
+
+    @waitForPublications = @fetchPublisherPublications refresh
+      .then @initPublicationsCollections.bind(@)
+
+  initPublicationsCollections: (publicationsData)->
+    { collections, editions } = publicationsData
+    collectionsUris = _.pluck(collections, 'uri')
+
+    isolatedEditions = editions.filter isntInAKnownCollection(collectionsUris)
+    isolatedEditionsUris = _.pluck isolatedEditions, 'uri'
+
+    @publisherCollections = new PaginatedEntities null, { uris: collectionsUris, defaultType: 'collection' }
+    @isolatedEditions = new PaginatedEntities null, { uris: isolatedEditionsUris, defaultType: 'edition' }
+
+isntInAKnownCollection = (collectionsUris)-> (edition)->
+  unless edition.collection? then return true
+  return edition.collection not in collectionsUris

--- a/app/modules/entities/lib/types/serie.coffee
+++ b/app/modules/entities/lib/types/serie.coffee
@@ -1,5 +1,6 @@
 PaginatedWorks = require '../../collections/paginated_works'
 commonsSerieWork = require './commons_serie_work'
+getPartsSuggestions = require 'modules/entities/views/cleanup/lib/get_parts_suggestions'
 
 module.exports = ->
   # Main property by which sub-entities are linked to this one
@@ -39,6 +40,10 @@ specificMethods = _.extend {}, commonsSerieWork,
     allAuthorsUris = getAuthors(@).concat @parts.map(getAuthors)...
     return _.uniq _.compact(allAuthorsUris)
 
+  getChildrenCandidatesUris: ->
+    getPartsSuggestions @
+    .then (suggestionsCollection)-> suggestionsCollection.map(getModelUri)
+
 initPartsCollections = (refresh, fetchAll, partsData)->
   allsPartsUris = _.pluck partsData, 'uri'
   partsWithoutSuperparts = partsData.filter hasNoKnownSuperpart(allsPartsUris)
@@ -68,5 +73,6 @@ importDataFromParts = ->
   if firstPartWithPublicationDate?
     @set 'publicationStart', getPublicationDate(firstPartWithPublicationDate)
 
+getModelUri = (model)-> model.get 'uri'
 getPublicationDate = (model)-> model.get 'claims.wdt:P577.0'
 getAuthors = (model)-> model.getExtendedAuthorsUris()

--- a/app/modules/entities/lib/types/type_key.coffee
+++ b/app/modules/entities/lib/types/type_key.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  pluralize: (type)->
+    if type.slice(-1)[0] isnt 's' then type += 's'
+    return type

--- a/app/modules/entities/models/entity.coffee
+++ b/app/modules/entities/models/entity.coffee
@@ -1,3 +1,9 @@
+# One unique Entity model to rule them all
+# but with specific initializers:
+# - By source:
+#   - Wikidata entities have specific initializers related to Wikimedia sitelinks
+# - By type: see specialInitializersByType
+
 isbn_ = require 'lib/isbn'
 entities_ = require '../lib/entities'
 initializeWikidataEntity = require '../lib/wikidata/init_entity'
@@ -14,18 +20,9 @@ specialInitializersByType =
   work: require '../lib/types/work'
   edition: require '../lib/types/edition'
   publisher: require '../lib/types/publisher'
+  collection: require '../lib/types/collection'
 
-# One unique Entity model to rule them all
-# but with specific initializers:
-# - By source:
-#   - Wikidata entities have specific initializers related to Wikimedia sitelinks
-# - By type:
-#   - Human (presumably an author)
-#   - Work
-#   - Edition
-
-# Progressively extending the allowlist of editable types
-editableTypes = [ 'work', 'edition', 'human', 'serie', 'publisher' ]
+editableTypes = Object.keys specialInitializersByType
 
 placeholdersTypes = [ 'meta', 'missing' ]
 

--- a/app/modules/entities/models/entity.coffee
+++ b/app/modules/entities/models/entity.coffee
@@ -132,18 +132,29 @@ module.exports = Filterable.extend
 
     collection = @[@subentitiesName] = new Backbone.Collection
 
+    uri = @get 'uri'
+    prop = @childrenClaimProperty
+
+    @waitForSubentities = @fetchSubEntitiesUris()
+      .then (uris)-> app.request 'get:entities:models', { uris, refresh }
+      .then @beforeSubEntitiesAdd.bind(@)
+      .then collection.add.bind(collection)
+      .tap @afterSubEntitiesAdd.bind(@)
+
+  fetchSubEntitiesUris: (refresh)->
+    refresh = @getRefresh refresh
+    if not refresh and @waitForSubentitiesUris? then return @waitForSubentitiesUris
+
     # A draft entity can't already have subentities
     if @creating then return @waitForSubentities = Promise.resolve()
 
     uri = @get 'uri'
     prop = @childrenClaimProperty
 
-    @waitForSubentities = entities_.getReverseClaims prop, uri, refresh
-      .tap @setSubEntitiesUris.bind(@)
-      .then (uris)-> app.request 'get:entities:models', { uris, refresh }
-      .then @beforeSubEntitiesAdd.bind(@)
-      .then collection.add.bind(collection)
-      .tap @afterSubEntitiesAdd.bind(@)
+    @waitForSubentitiesUris = entities_.getReverseClaims prop, uri, refresh
+      .then (uris)=>
+        @setSubEntitiesUris uris
+        return uris
 
   # Override in sub-types
   beforeSubEntitiesAdd: _.identity

--- a/app/modules/entities/models/entity.coffee
+++ b/app/modules/entities/models/entity.coffee
@@ -135,6 +135,10 @@ module.exports = Filterable.extend
     uri = @get 'uri'
     prop = @childrenClaimProperty
 
+    # Known case: when called on an instance of entity_draft_model
+    unless uri?
+      return @waitForSubentities = Promise.resolve()
+
     @waitForSubentities = @fetchSubEntitiesUris()
       .then (uris)-> app.request 'get:entities:models', { uris, refresh }
       .then @beforeSubEntitiesAdd.bind(@)

--- a/app/modules/entities/models/search_result.coffee
+++ b/app/modules/entities/models/search_result.coffee
@@ -10,9 +10,9 @@ module.exports = Filterable.extend
   initialize: ->
     { lang } = app.user
 
-    [ labels, descriptions ] = @gets 'labels', 'descriptions'
+    [ label, labels, descriptions ] = @gets 'label', 'labels', 'descriptions'
 
-    if labels?
+    if not label? and labels?
       @set 'label', getBestLangValue(lang, null, labels).value
 
     if descriptions?

--- a/app/modules/entities/scss/_author_infobox.scss
+++ b/app/modules/entities/scss/_author_infobox.scss
@@ -1,6 +1,6 @@
 $author-data-threshold: 25em;
 
-.authorInfobox, .publisherInfobox{
+.authorInfobox, .publisherInfobox, .collectionInfobox{
   margin: 0 auto;
   max-width: 60em;
   // center the image
@@ -38,7 +38,8 @@ $author-data-threshold: 25em;
     }
   }
 }
-.authorData, .publisherData{
+
+.authorData, .publisherData, .collectionData{
   position: relative;
   background-color: $darker-grey;
   @include radius;

--- a/app/modules/entities/scss/_author_layout.scss
+++ b/app/modules/entities/scss/_author_layout.scss
@@ -1,6 +1,6 @@
 $author-layout-bg: #292929;
 
-.authorLayout, #publisherLayout, #collectionLayout{
+.authorLayout, #publisherLayout, .collectionLayout{
   background-color: $author-layout-bg;
   // allow to have no margin when there is only one .authorLayout
   &:not(:first-child){
@@ -146,7 +146,7 @@ $author-layout-bg: #292929;
   }
 }
 
-.authorLayout, #workLayout, .serieLayout, #publisherLayout, #collectionLayout{
+.authorLayout, #workLayout, .serieLayout, #publisherLayout, .collectionLayout{
   .admin{
     background-color: $darker-grey;
     @include radius;

--- a/app/modules/entities/scss/_author_layout.scss
+++ b/app/modules/entities/scss/_author_layout.scss
@@ -1,6 +1,6 @@
 $author-layout-bg: #292929;
 
-.authorLayout, #publisherLayout{
+.authorLayout, #publisherLayout, #collectionLayout{
   background-color: $author-layout-bg;
   // allow to have no margin when there is only one .authorLayout
   &:not(:first-child){
@@ -146,7 +146,7 @@ $author-layout-bg: #292929;
   }
 }
 
-.authorLayout, #workLayout, .serieLayout, #publisherLayout{
+.authorLayout, #workLayout, .serieLayout, #publisherLayout, #collectionLayout{
   .admin{
     background-color: $darker-grey;
     @include radius;

--- a/app/modules/entities/scss/_claim_layout.scss
+++ b/app/modules/entities/scss/_claim_layout.scss
@@ -32,4 +32,7 @@
       }
     }
   }
+  .addOne{
+    margin: 1em;
+  }
 }

--- a/app/modules/entities/scss/_claim_layout.scss
+++ b/app/modules/entities/scss/_claim_layout.scss
@@ -9,7 +9,7 @@
         max-width: 20em;
         text-align: center;
       }
-      .data{
+      .entity-data-box{
         max-width: 40em;
         &, h2, a.showEntity{
           color: white;

--- a/app/modules/entities/scss/_edition_commons.scss
+++ b/app/modules/entities/scss/_edition_commons.scss
@@ -18,7 +18,9 @@
     a{
       text-wrap: nowrap;
     }
-    padding: 1em 0;
+    &:not(:empty){
+      padding: 1em 0;
+    }
   }
   .subtitle{
     @include serif;

--- a/app/modules/entities/scss/_entities.scss
+++ b/app/modules/entities/scss/_entities.scss
@@ -12,6 +12,7 @@
 @import 'author_layout';
 @import 'infoboxes';
 @import 'entities_list';
+@import 'entities_list_adder';
 @import 'serie_layout';
 @import 'serie_cleanup';
 @import 'claim_layout';

--- a/app/modules/entities/scss/_entities_list.scss
+++ b/app/modules/entities/scss/_entities_list.scss
@@ -4,7 +4,8 @@
   div.works-list-controls{
     @include display-flex(row, center, center, wrap);
     text-align: center;
-    a{
+    button{
+      font-weight: normal;
       height: 3em;
       max-width: 15em;
       padding: 1em;
@@ -17,7 +18,7 @@
         @include display-flex(row, center, center);
       }
     }
-    a.displayMore{
+    .displayMore{
       .counter{
         background-color: $grey;
         color: white;

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -9,11 +9,15 @@
   .context{
     margin-bottom: 1em;
   }
-  .create{
-    margin: 1em;
-  }
   .no-suggestion{
     color: $grey;
+  }
+  .buttons{
+    margin: 1em;
+    @include display-flex(row, center, center);
+    a{
+      margin: 1em;
+    }
   }
 }
 

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -81,6 +81,11 @@
     white-space: nowrap;
     flex: 0 0 auto;
   }
+  .warning{
+    color: $grey;
+    max-width: 10em;
+    text-align: center;;
+  }
   .added{
     color: $grey;
   }

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -34,19 +34,18 @@
 }
 
 .entitiesListElementCandidates{
-  max-height: 50vh;
+  height: 50vh;
   overflow-y: auto;
 }
 
 .entities-list-element-candidate{
+  @include display-flex(row, center, center);
   background-color: #f3f3f3;
   padding: 0.5em;
   @include radius;
-  @include display-flex(row, center, center);
-  flex: 1 1 0;
   margin: 0.5em 0;
   .showEntity{
-    @include display-flex(row, center, center);
+    flex: 1 1 0;
     margin: 0.5em;
     color: $dark-grey;
   }
@@ -61,7 +60,6 @@
   }
   .label, .description{
     margin-right: 0.5em;
-    white-space: nowrap;
     flex: 0 0 auto;
   }
   .label{
@@ -75,7 +73,7 @@
     overflow: hidden;
   }
   .status{
-    @include display-flex(column);
+    width: 10em;
   }
   .add, .added{
     white-space: nowrap;
@@ -95,20 +93,12 @@
   max-width: 20em;
 }
 
-
 /*Very Small screens*/
-@media screen and (max-width: $very-small-screen) {
+@media screen and (max-width: $smaller-screen) {
+  #entitiesListAdder{
+    padding: 0 0.5em;
+  }
   .entities-list-element-candidate{
-    @include display-flex(column, center, center);
-  }
-  .showEntity{
-    @include display-flex(column, center, center);
-  }
-}
-
-/*Large screens*/
-@media screen and (min-width: $very-small-screen) {
-  .status{
-    margin-left: auto;
+    flex-direction: column;
   }
 }

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -12,19 +12,36 @@
   .create{
     margin: 1em;
   }
+  .no-suggestion{
+    color: $grey;
+  }
+}
+
+.entitiesListElementCandidates{
+  max-height: 50vh;
+  overflow-y: auto;
 }
 
 .entities-list-element-candidate{
+  background-color: #f3f3f3;
+  padding: 0.5em;
+  @include radius;
   @include display-flex(row, center, center);
+  flex: 1 1 0;
   margin: 0.5em 0;
   .showEntity{
-    flex: 1;
-    @include display-flex(row);
+    @include display-flex(row, center, center);
     margin: 0.5em;
     color: $dark-grey;
   }
-  .image{
+  .info{
+    overflow: hidden;
+    padding: 0.5em;
+    max-width: 25em;
+  }
+  .image-wrapper{
     margin-right: 0.3em;
+    max-width: 10em;
   }
   .label, .description{
     margin-right: 0.5em;
@@ -34,17 +51,40 @@
   .label{
     font-size: 1.1rem;
   }
-  .info{
-    flex: 1;
-    @include display-flex(column, flex-start, flex-start);
-    padding: 1em;
-  }
   .description{
-    flex: 0 1 auto;
-    overflow: hidden;
     color: $grey;
+  }
+  .claims{
+    flex: 1 0 0;
+    overflow: hidden;
+  }
+  .add, .added{
+    white-space: nowrap;
+    flex: 0 0 auto;
   }
   .added{
     color: $grey;
+  }
+}
+
+#searchCandidates{
+  max-width: 20em;
+}
+
+
+/*Very Small screens*/
+@media screen and (max-width: $very-small-screen) {
+  .entities-list-element-candidate{
+    @include display-flex(column, center, center);
+  }
+  .showEntity{
+    @include display-flex(column, center, center);
+  }
+}
+
+/*Large screens*/
+@media screen and (min-width: $very-small-screen) {
+  .status{
+    margin-left: auto;
   }
 }

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -17,6 +17,18 @@
     @include display-flex(row, center, center);
     a{
       margin: 1em;
+      text-align: center;
+      min-width: 6em;
+    }
+  }
+  &.fetching{
+    .no-suggestion{
+      display: none;
+    }
+  }
+  &:not(.fetching){
+    .centered-loader{
+      display: none;
     }
   }
 }

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -1,0 +1,50 @@
+#entitiesListAdder{
+  @include display-flex(column, center, center);
+  h3{
+    text-align: center;
+  }
+  .parent-label{
+    color: $grey;
+  }
+  .context{
+    margin-bottom: 1em;
+  }
+  .create{
+    margin: 1em;
+  }
+}
+
+.entities-list-element-candidate{
+  @include display-flex(row, center, center);
+  margin: 0.5em 0;
+  .showEntity{
+    flex: 1;
+    @include display-flex(row);
+    margin: 0.5em;
+    color: $dark-grey;
+  }
+  .image{
+    margin-right: 0.3em;
+  }
+  .label, .description{
+    margin-right: 0.5em;
+    white-space: nowrap;
+    flex: 0 0 auto;
+  }
+  .label{
+    font-size: 1.1rem;
+  }
+  .info{
+    flex: 1;
+    @include display-flex(column, flex-start, flex-start);
+    padding: 1em;
+  }
+  .description{
+    flex: 0 1 auto;
+    overflow: hidden;
+    color: $grey;
+  }
+  .added{
+    color: $grey;
+  }
+}

--- a/app/modules/entities/scss/_entities_list_adder.scss
+++ b/app/modules/entities/scss/_entities_list_adder.scss
@@ -74,6 +74,9 @@
     flex: 1 0 0;
     overflow: hidden;
   }
+  .status{
+    @include display-flex(column);
+  }
   .add, .added{
     white-space: nowrap;
     flex: 0 0 auto;

--- a/app/modules/entities/scss/_entity_create.scss
+++ b/app/modules/entities/scss/_entity_create.scss
@@ -1,12 +1,14 @@
 #entityCreate{
   .typePicker{
     text-align: center;
-    @include display-flex(row, center, center);
+    @include display-flex(row, center, center, wrap);
+    margin: 4em 0.5em 2em 0.5em;
     a{
       @include big-button($grey);
       padding: 1em;
       margin: 0.1em;
-      flex: 1 0 auto;
+      flex: 1 0 5em;
+      max-width: 10em;
       &.selected{
         @include bg-hover(white, 0%);
         color: $dark-grey;

--- a/app/modules/entities/scss/_entity_create.scss
+++ b/app/modules/entities/scss/_entity_create.scss
@@ -19,11 +19,14 @@
   /*Large screens*/
   @media screen and (min-width: $smaller-screen) {
     .typePicker{
-      max-width: 30em;
+      max-width: 50em;
       margin: 0 auto;
       // Using vertical padding instead of vertical margin
       // as the margin behaves weirdly: for some reason, it overlapses with the topbar
       padding: 1em 0;
+      a{
+        flex: 1 0 0;
+      }
     }
   }
 }

--- a/app/modules/entities/scss/_entity_edit.scss
+++ b/app/modules/entities/scss/_entity_edit.scss
@@ -72,6 +72,11 @@ $entity-editor-small-thresold: 800px;
       }
     }
   }
+  .missingDataMessage{
+    background-color: #ddd;
+    padding: 1em;
+    @include radius;
+  }
 }
 
 .identifier{

--- a/app/modules/entities/scss/_infoboxes.scss
+++ b/app/modules/entities/scss/_infoboxes.scss
@@ -1,4 +1,4 @@
-.authorInfobox, .serieInfobox, .generalInfobox{
+.authorInfobox, .serieInfobox, .generalInfobox, .collectionInfobox{
   h2{
     font-size: 1.6em;
   }
@@ -33,7 +33,7 @@
 }
 
 // Excluding the edition layout
-.authorInfobox, .serieInfobox, .workInfobox, .publisherInfobox{
+.authorInfobox, .serieInfobox, .workInfobox, .publisherInfobox, .collectionInfobox{
   .entity-data-box{
     background-color: $darker-grey;
   }

--- a/app/modules/entities/scss/_publisher_layout.scss
+++ b/app/modules/entities/scss/_publisher_layout.scss
@@ -1,5 +1,5 @@
 // See also author_layout
-#publisherLayout{
+#publisherLayout, #collectionLayout{
   #editionsList{
     margin-bottom: 1em;
   }

--- a/app/modules/entities/scss/_publisher_layout.scss
+++ b/app/modules/entities/scss/_publisher_layout.scss
@@ -1,6 +1,20 @@
 // See also author_layout
-#publisherLayout, #collectionLayout{
-  #editionsList{
-    margin-bottom: 1em;
+#publisherLayout, .collectionLayout{
+  padding: 1em;
+  .entitiesList{
+    margin: 1em auto;
+    .header{
+      h3{
+        color: white;
+      }
+      @include display-flex(row, center, center);
+    }
+  }
+}
+
+#publisherLayout{
+  .collectionLayout{
+    background-color: #ddd;
+    margin: 2em 0;
   }
 }

--- a/app/modules/entities/views/author_layout.coffee
+++ b/app/modules/entities/views/author_layout.coffee
@@ -86,5 +86,10 @@ module.exports = TypedEntityLayout.extend
       initialLength: initialLength
       showActions: @options.showActions
       wrapWorks: @options.wrapWorks
+      addButtonLabel: addButtonLabelPerType[type]
+
+addButtonLabelPerType =
+  works: 'add a work from this author'
+  series: 'add a serie from this author'
 
 dropThePlural = (type)-> type.replace /s$/, ''

--- a/app/modules/entities/views/claim_layout.coffee
+++ b/app/modules/entities/views/claim_layout.coffee
@@ -25,6 +25,7 @@ module.exports = Marionette.LayoutView.extend
     .catch @displayError
 
     entities_.getReverseClaims @property, @value, @refresh, true
+    .tap => @waitForModel
     .then @ifViewIsIntact('showEntities')
     .catch @displayError
 

--- a/app/modules/entities/views/claim_layout.coffee
+++ b/app/modules/entities/views/claim_layout.coffee
@@ -53,3 +53,8 @@ module.exports = Marionette.LayoutView.extend
       canAddOne: true
       standalone: true
       refresh: @refresh
+      addButtonLabel: addButtonLabelPerProperty[@property]
+
+addButtonLabelPerProperty =
+  'wdt:P921':
+    work: 'add a work with this subject'

--- a/app/modules/entities/views/claim_layout.coffee
+++ b/app/modules/entities/views/claim_layout.coffee
@@ -42,11 +42,13 @@ module.exports = Marionette.LayoutView.extend
     propertyValue = _.i18n wd_.unprefixify(@property)
     entityValue = entityValueTemplate @value
 
-    @list.show new EntitiesList {
+    @list.show new EntitiesList
       title: "#{propertyValue}: #{entityValue}"
       customTitle: true
+      parentModel: @model
+      childrenClaimProperty: @property
+      type: 'work'
       collection: collection
-      canAddOne: false
-      standalone: true,
+      canAddOne: true
+      standalone: true
       refresh: @refresh
-    }

--- a/app/modules/entities/views/collection_layout.coffee
+++ b/app/modules/entities/views/collection_layout.coffee
@@ -1,13 +1,13 @@
 TypedEntityLayout = require './typed_entity_layout'
-EditionsList = require './editions_list'
+EntitiesList = require './entities_list'
 GeneralInfobox = require './general_infobox'
+PaginatedEntities = require 'modules/entities/collections/paginated_entities'
 
 Infobox = GeneralInfobox.extend
   template: require './templates/collection_infobox.hbs'
 
 module.exports = TypedEntityLayout.extend
-  id: 'collectionLayout'
-  className: 'standalone'
+  baseClassName: 'collectionLayout'
   template: require './templates/collection_layout'
   Infobox: Infobox
   regions:
@@ -16,10 +16,18 @@ module.exports = TypedEntityLayout.extend
     mergeSuggestionsRegion: '.mergeSuggestions'
 
   onShow: ->
-    unless @standalone? then return
+    @model.fetchSubEntitiesUris @refresh
+    .then @ifViewIsIntact('showPaginatedEditions')
 
-    @model.fetchSubEntities @refresh
-    .then @ifViewIsIntact('showEditions')
+  serializeData: ->
+    standalone: @standalone
 
-  showEditions: ->
-    @editionsList.show new EditionsList { collection: @model.editions, sortByLang: false }
+  showPaginatedEditions: (uris)->
+    collection = new PaginatedEntities null, { uris, defaultType: 'edition' }
+    @editionsList.show new EntitiesList
+      collection: collection
+      hideHeader: not @standalone
+      compactMode: true
+      parentModel: @model
+      type: 'edition'
+      title: 'editions'

--- a/app/modules/entities/views/collection_layout.coffee
+++ b/app/modules/entities/views/collection_layout.coffee
@@ -22,4 +22,4 @@ module.exports = TypedEntityLayout.extend
     .then @ifViewIsIntact('showEditions')
 
   showEditions: ->
-    @editionsList.show new EditionsList { collection: @model.editions }
+    @editionsList.show new EditionsList { collection: @model.editions, sortByLang: false }

--- a/app/modules/entities/views/collection_layout.coffee
+++ b/app/modules/entities/views/collection_layout.coffee
@@ -31,3 +31,4 @@ module.exports = TypedEntityLayout.extend
       parentModel: @model
       type: 'edition'
       title: 'editions'
+      addButtonLabel: 'add an edition to this collection'

--- a/app/modules/entities/views/collection_layout.coffee
+++ b/app/modules/entities/views/collection_layout.coffee
@@ -1,0 +1,25 @@
+TypedEntityLayout = require './typed_entity_layout'
+EditionsList = require './editions_list'
+GeneralInfobox = require './general_infobox'
+
+Infobox = GeneralInfobox.extend
+  template: require './templates/collection_infobox.hbs'
+
+module.exports = TypedEntityLayout.extend
+  id: 'collectionLayout'
+  className: 'standalone'
+  template: require './templates/collection_layout'
+  Infobox: Infobox
+  regions:
+    infoboxRegion: '.collectionInfobox'
+    editionsList: '#editionsList'
+    mergeSuggestionsRegion: '.mergeSuggestions'
+
+  onShow: ->
+    unless @standalone? then return
+
+    @model.fetchSubEntities @refresh
+    .then @ifViewIsIntact('showEditions')
+
+  showEditions: ->
+    @editionsList.show new EditionsList { collection: @model.editions }

--- a/app/modules/entities/views/edition_li.coffee
+++ b/app/modules/entities/views/edition_li.coffee
@@ -16,17 +16,20 @@ module.exports = Marionette.LayoutView.extend
     entityActions: '.editionEntityActions'
 
   initialize: ->
-    { @itemToUpdate } = @options
-    unless @itemToUpdate? then entityItems.initialize.call @
+    { @itemToUpdate, @compactMode, @onWorkLayout } = @options
+    unless @itemToUpdate? or @compactMode then entityItems.initialize.call @
 
   onRender: ->
-    unless @itemToUpdate? then @lazyShowItems()
+    unless @itemToUpdate? or @compactMode then @lazyShowItems()
     @showEntityActions()
 
   serializeData: ->
     _.extend @model.toJSON(),
       itemUpdateContext: @itemToUpdate?
-      onWorkLayout: @options.onWorkLayout
+      onWorkLayout: @onWorkLayout
+      compactMode: @compactMode
+      itemsListsDisabled: @itemToUpdate or @compactMode
 
   showEntityActions: ->
+    if @compactMode then return
     @entityActions.show new EntityActions { @model, @itemToUpdate }

--- a/app/modules/entities/views/editions_list.coffee
+++ b/app/modules/entities/views/editions_list.coffee
@@ -18,10 +18,11 @@ module.exports = Marionette.CompositeView.extend
     PreventDefault: {}
 
   initialize: ->
-    { @work } = @options
+    { @work, @sortByLang } = @options
+    @sortByLang ?= true
 
     # Start with user lang as default if there are editions in that language
-    if app.user.lang in @getAvailableLangs()
+    if @sortByLang and app.user.lang in @getAvailableLangs()
       @filter = LangFilter app.user.lang
     @selectedLang = app.user.lang
 
@@ -58,6 +59,7 @@ module.exports = Marionette.CompositeView.extend
   serializeData: ->
     hasEditions: @collection.length > 0
     hasWork: @work?
+    sortByLang: @sortByLang
     availableLanguages: @getAvailableLanguages @selectedLang
     editionCreationData: partialData @work
     header: @options.header or 'editions'

--- a/app/modules/entities/views/editions_list.coffee
+++ b/app/modules/entities/views/editions_list.coffee
@@ -10,6 +10,7 @@ module.exports = Marionette.CompositeView.extend
   childViewOptions: ->
     itemToUpdate: @options.itemToUpdate
     onWorkLayout: @options.onWorkLayout
+    compactMode: @options.compactMode
 
   behaviors:
     Loading: {}
@@ -62,7 +63,8 @@ module.exports = Marionette.CompositeView.extend
     sortByLang: @sortByLang
     availableLanguages: @getAvailableLanguages @selectedLang
     editionCreationData: partialData @work
-    header: @options.header or 'editions'
+    # @options.header can be 'false', thus the existance test
+    header: if @options.header? then @options.header else 'editions'
 
   events:
     'change .languageFilter': 'filterLanguageFromEvent'

--- a/app/modules/entities/views/editor/entity_edit.coffee
+++ b/app/modules/entities/views/editor/entity_edit.coffee
@@ -173,6 +173,9 @@ module.exports = Marionette.LayoutView.extend
   setMissingRequiredProperties: ->
     @missingRequiredProperties = []
 
+    unless _.values(@model.get('labels')).length > 0
+      @missingRequiredProperties.push _.i18n('title')
+
     for property in @requiredProperties
       unless @model.get("claims.#{property}")?.length > 0
         labelKey = propertiesPerType[@model.type][property].customLabel or property

--- a/app/modules/entities/views/editor/entity_edit.coffee
+++ b/app/modules/entities/views/editor/entity_edit.coffee
@@ -9,6 +9,15 @@ properties = require 'modules/entities/lib/properties'
 moveToWikidata = require './lib/move_to_wikidata'
 { startLoading } = require 'modules/general/plugins/behaviors'
 error_ = require 'lib/error'
+typesWithoutLabel = [
+  'edition',
+  'collection'
+]
+# Keep in sync with server/controllers/entities/lib/validate_critical_claims.js
+requiredPropertyPerType =
+  edition: [ 'wdt:P629', 'wdt:P1476' ]
+  collection: [ 'wdt:P1476', 'wdt:P123' ]
+propertiesPerType = require 'modules/entities/lib/editor/properties_per_type'
 
 module.exports = Marionette.LayoutView.extend
   id: 'entityEdit'
@@ -25,12 +34,17 @@ module.exports = Marionette.LayoutView.extend
 
   ui:
     navigationButtons: '.navigationButtons'
+    missingDataMessage: '.missingDataMessage'
 
   initialize: ->
     @creationMode = @model.creating
-    @requiresLabel = @model.type isnt 'edition'
+    @requiresLabel = @model.type not in typesWithoutLabel
+    @requiredProperties = requiredPropertyPerType[@model.type] or []
     @canBeAddedToInventory = @model.type in inventoryTypes
     @showAdminSection = app.user.hasDataadminAccess and not @creationMode
+
+    if @creationMode
+      @setMissingRequiredProperties()
 
     if @model.subEntitiesInverseProperty?
       @waitForPropCollection = @model.fetchSubEntities()
@@ -76,6 +90,7 @@ module.exports = Marionette.LayoutView.extend
     # Used when item_show attempts to 'preciseEdition' with a new edition
     attrs.itemToUpdate = @itemToUpdate
     attrs.canBeAddedToInventory = @canBeAddedToInventory
+    attrs.missingRequiredProperties = @missingRequiredProperties
     return attrs
 
   events:
@@ -137,15 +152,33 @@ module.exports = Marionette.LayoutView.extend
   # Hiding navigation buttons when a label is required but no label is set yet
   # to invite the user to edit and save the label, or cancel.
   updateNavigationButtons: ->
-    labelsCount = _.values(@model.get('labels')).length
-    if @requiresLabel and labelsCount is 0
+    if @missingData()
       unless @navigationButtonsDisabled
         @ui.navigationButtons.hide()
+        @ui.missingDataMessage.show()
         @navigationButtonsDisabled = true
+      @$el.find('span.missingProperties').text @missingRequiredProperties.join(', ')
     else
       if @navigationButtonsDisabled
         @ui.navigationButtons.fadeIn()
+        @ui.missingDataMessage.hide()
         @navigationButtonsDisabled = false
+
+  missingData: ->
+    labelsCount = _.values(@model.get('labels')).length
+    if @requiresLabel and labelsCount is 0 then return true
+    @setMissingRequiredProperties()
+    return @missingRequiredProperties.length > 0
+
+  setMissingRequiredProperties: ->
+    @missingRequiredProperties = []
+
+    for property in @requiredProperties
+      unless @model.get("claims.#{property}")?.length > 0
+        labelKey = propertiesPerType[@model.type][property].customLabel or property
+        @missingRequiredProperties.push _.i18n(labelKey)
+
+    return
 
   moveToWikidataData: ->
     uri = @model.get 'uri'

--- a/app/modules/entities/views/editor/entity_edit.coffee
+++ b/app/modules/entities/views/editor/entity_edit.coffee
@@ -190,5 +190,6 @@ possessives =
   serie: "series'"
   human: "author's"
   publisher: "publisher's"
+  collection: "collection's"
 
 inventoryTypes = [ 'work', 'edition' ]

--- a/app/modules/entities/views/editor/entity_value_editor.coffee
+++ b/app/modules/entities/views/editor/entity_value_editor.coffee
@@ -162,3 +162,4 @@ createdEntityType =
   humans: 'author'
   series: 'serie'
   publishers: 'publisher'
+  collections: 'collection'

--- a/app/modules/entities/views/editor/lib/suggestions/wdt_P123.coffee
+++ b/app/modules/entities/views/editor/lib/suggestions/wdt_P123.coffee
@@ -1,7 +1,22 @@
 { getReverseClaims } = require 'modules/entities/lib/entities'
 
 module.exports = (entity, index, propertyValuesCount)->
+  promises = []
   isbn13h = entity.get 'claims.wdt:P212.0'
-  isbnPublisherPrefix = isbn13h.split('-').slice(0, 3).join('-')
 
-  return getReverseClaims 'wdt:P3035', isbnPublisherPrefix
+  if isbn13h?
+    isbnPublisherPrefix = isbn13h.split('-').slice(0, 3).join('-')
+    promises.push getReverseClaims('wdt:P3035', isbnPublisherPrefix)
+
+  collectionsUris = entity.get('claims.wdt:P195')
+  if collectionsUris? then promises.push getCollectionsPublishers(collectionsUris)
+
+  return Promise.all promises
+  .then _.flatten
+  .then _.uniq
+
+getCollectionsPublishers = (collectionsUris)->
+  app.request 'get:entities:models', { uris: collectionsUris }
+  .then (entities)-> _.flatten(entities.map(parseCollectionPublishers))
+
+parseCollectionPublishers = (entity)-> entity.get('claims.wdt:P123')

--- a/app/modules/entities/views/editor/templates/autocomplete_no_suggestion.hbs
+++ b/app/modules/entities/views/editor/templates/autocomplete_no_suggestion.hbs
@@ -1,1 +1,1 @@
-<a>{{i18n 'no suggestion found'}}</a>
+<span>{{i18n 'no suggestion found'}}</span>

--- a/app/modules/entities/views/editor/templates/entity_create.hbs
+++ b/app/modules/entities/views/editor/templates/entity_create.hbs
@@ -3,5 +3,6 @@
   <a id="seriePicker">{{I18n 'serie'}}</a>
   <a id="humanPicker">{{I18n 'author'}}</a>
   <a id="publisherPicker">{{I18n 'publisher'}}</a>
+  <a id="collectionPicker">{{I18n 'collection'}}</a>
 </div>
 <div id="typedEntityEdit"></div>

--- a/app/modules/entities/views/editor/templates/entity_edit.hbs
+++ b/app/modules/entities/views/editor/templates/entity_edit.hbs
@@ -32,6 +32,12 @@
           {{I18n 'cancel'}}
       </a>
     {{/if}}
+    <div class="missingDataMessage">
+      <p>
+        {{I18n 'required properties are missing'}}:
+        <span class="missingProperties">{{join missingRequiredProperties}}</span>
+      </p>
+    </div>
     {{#if next}}
       <a id="next" class="navigationButtons light-blue-button" tabindex="0">
         {{icon 'arrow-right'}}

--- a/app/modules/entities/views/editor/templates/entity_edit.hbs
+++ b/app/modules/entities/views/editor/templates/entity_edit.hbs
@@ -32,12 +32,14 @@
           {{I18n 'cancel'}}
       </a>
     {{/if}}
-    <div class="missingDataMessage">
-      <p>
-        {{I18n 'required properties are missing'}}:
-        <span class="missingProperties">{{join missingRequiredProperties}}</span>
-      </p>
-    </div>
+    {{#if missingRequiredProperties}}
+      <div class="missingDataMessage">
+        <p>
+          {{I18n 'required properties are missing'}}:
+          <span class="missingProperties">{{join missingRequiredProperties}}</span>
+        </p>
+      </div>
+    {{/if}}
     {{#if next}}
       <a id="next" class="navigationButtons light-blue-button" tabindex="0">
         {{icon 'arrow-right'}}

--- a/app/modules/entities/views/entities_list.coffee
+++ b/app/modules/entities/views/entities_list.coffee
@@ -52,7 +52,7 @@ module.exports = Marionette.CompositeView.extend
     moreCounter: '.displayMore .counter'
 
   initialize: ->
-    { @parentModel } = @options
+    { @parentModel, @addButtonLabel } = @options
     @childrenClaimProperty = @options.childrenClaimProperty or @parentModel.childrenClaimProperty
     initialLength = @options.initialLength or 5
     @batchLength = @options.batchLength or 15
@@ -64,7 +64,6 @@ module.exports = Marionette.CompositeView.extend
 
     parentType = @parentModel.type
     childrenType = @options.type
-    @addOneLabel = getAddLabel(parentType, childrenType, @childrenClaimProperty)
 
   serializeData: ->
     title: @options.title
@@ -72,11 +71,11 @@ module.exports = Marionette.CompositeView.extend
     hideHeader: @options.hideHeader
     more: @more()
     totalLength: @collection.totalLength
-    addOneLabel: @addOneLabel
+    addButtonLabel: @addButtonLabel
 
   events:
-    'click a.displayMore': 'displayMore'
-    'click a.addOne': 'addOne'
+    'click .displayMore': 'displayMore'
+    'click .addOne': 'addOne'
 
   displayMore: ->
     @startMoreLoading()
@@ -104,24 +103,3 @@ module.exports = Marionette.CompositeView.extend
     }
     # Prevent nested entities list to trigger that same event on the parent list
     e.stopPropagation()
-
-getAddLabel = (parentType, childrenType, property)->
-  addOneLabels[parentType]?[childrenType] or addOneLabels[property]?[childrenType]
-
-addOneLabels =
-  # parent model type
-  human:
-    # list elements type
-    work: 'add a work from this author'
-    serie: 'add a serie from this author'
-  serie:
-    work: 'add a work to this serie'
-  publisher:
-    edition: 'add an edition from this publisher'
-    collection: 'add a collection from this publisher'
-  collection:
-    edition: 'add an edition to this collection'
-
-  # parent-children relation property
-  'wdt:P921':
-    work: 'add a work with this subject'

--- a/app/modules/entities/views/entities_list.coffee
+++ b/app/modules/entities/views/entities_list.coffee
@@ -1,6 +1,6 @@
 loader = require 'modules/general/views/templates/loader'
 error_ = require 'lib/error'
-canAddOneTypeList = [ 'serie', 'work' ]
+canAddOneTypeList = [ 'serie', 'work', 'edition', 'collection' ]
 { buildPath } = require 'lib/location'
 
 # TODO:
@@ -17,6 +17,8 @@ module.exports = Marionette.CompositeView.extend
     PreventDefault: {}
 
   childViewContainer: '.container'
+  tagName: -> if @options.type is 'edition' then 'ul' else 'div'
+
   getChildView: (model)->
     { type } = model
     switch type
@@ -26,9 +28,10 @@ module.exports = Marionette.CompositeView.extend
       # Types included despite not being works
       # to make this view reusable by ./claim_layout with those types.
       # This view should thus possibily be renamed entities_list
-      when 'edition' then require './edition_layout'
+      when 'edition' then require './edition_li'
       when 'human' then require './author_layout'
       when 'publisher' then require './publisher_layout'
+      when 'collection' then require './collection_layout'
       else
         err = error_.new "unknown entity type: #{type}", model
         # Weird: errors thrown here don't appear anyware
@@ -40,6 +43,7 @@ module.exports = Marionette.CompositeView.extend
     refresh: @options.refresh
     showActions: @options.showActions
     wrap: @options.wrapWorks
+    compactMode: @options.compactMode
 
   ui:
     counter: '.counter'
@@ -76,6 +80,9 @@ module.exports = Marionette.CompositeView.extend
 
     if parentType is 'serie'
       claims['wdt:P50'] = parentModel.get 'claims.wdt:P50'
+
+    else if parentType is 'collection'
+      claims['wdt:P123'] = parentModel.get 'claims.wdt:P123'
 
     href = buildPath '/entity/new', { type, claims }
 
@@ -120,3 +127,8 @@ addOneLabels =
     serie: 'add a serie from this author'
   serie:
     work: 'add a work to this serie'
+  publisher:
+    edition: 'add an edition from this publisher'
+    collection: 'add a collection from this publisher'
+  collection:
+    edition: 'add an edition to this collection'

--- a/app/modules/entities/views/entities_list.coffee
+++ b/app/modules/entities/views/entities_list.coffee
@@ -68,7 +68,7 @@ module.exports = Marionette.CompositeView.extend
     hideHeader: @options.hideHeader
     more: @more()
     totalLength: @collection.totalLength
-    addOneLabel: addOneLabels[@parentModel.type][@options.type]
+    addOneLabel: addOneLabels[@parentModel?.type]?[@options.type]
 
   events:
     'click a.displayMore': 'displayMore'
@@ -91,7 +91,7 @@ module.exports = Marionette.CompositeView.extend
   addOne: ->
     unless app.request 'require:loggedIn', currentRoute() then return
     { type, parentModel } = @options
-    header = addOneLabels[@parentModel.type][@options.type]
+    header = addOneLabels[@parentModel.type][type]
     app.layout.modal.show new EntitiesListAdder { header, type, parentModel, listCollection: @collection }
 
 addOneLabels =

--- a/app/modules/entities/views/entities_list.coffee
+++ b/app/modules/entities/views/entities_list.coffee
@@ -88,11 +88,13 @@ module.exports = Marionette.CompositeView.extend
   startMoreLoading: ->
     @ui.moreCounter.html loader()
 
-  addOne: ->
+  addOne: (e)->
     unless app.request 'require:loggedIn', currentRoute() then return
     { type, parentModel } = @options
     header = addOneLabels[@parentModel.type][type]
     app.layout.modal.show new EntitiesListAdder { header, type, parentModel, listCollection: @collection }
+    # Prevent nested entities list to trigger that same event on the parent list
+    e.stopPropagation()
 
 addOneLabels =
   # parent model type

--- a/app/modules/entities/views/entities_list.coffee
+++ b/app/modules/entities/views/entities_list.coffee
@@ -95,7 +95,13 @@ module.exports = Marionette.CompositeView.extend
   addOne: (e)->
     unless app.request 'require:loggedIn', currentRoute() then return
     { type, parentModel } = @options
-    app.layout.modal.show new EntitiesListAdder { header: @addOneLabel, type, parentModel, listCollection: @collection }
+    app.layout.modal.show new EntitiesListAdder {
+      header: @addOneLabel,
+      type,
+      @childrenClaimProperty
+      parentModel,
+      listCollection: @collection,
+    }
     # Prevent nested entities list to trigger that same event on the parent list
     e.stopPropagation()
 

--- a/app/modules/entities/views/entities_list_adder.coffee
+++ b/app/modules/entities/views/entities_list_adder.coffee
@@ -68,9 +68,12 @@ module.exports = Marionette.CompositeView.extend
   search: (e)->
     { value: input } = e.currentTarget
 
-    if input is '' and @_lastInput?
-      @_lastInput = null
-      @addCandidates()
+    if input is ''
+      if @_lastInput?
+        @_lastInput = null
+        @addCandidates()
+      else
+        return
 
     @_lastInput = input
     typeSearch @type, input

--- a/app/modules/entities/views/entities_list_adder.coffee
+++ b/app/modules/entities/views/entities_list_adder.coffee
@@ -1,0 +1,59 @@
+{ buildPath } = require 'lib/location'
+EntitiesListElementCandidate = require './entities_list_element_candidate'
+
+module.exports = Marionette.CompositeView.extend
+  id: 'entitiesListAdder'
+  template: require './templates/entities_list_adder'
+  childViewContainer: '.entitiesListElementCandidates'
+  childView: EntitiesListElementCandidate
+  childViewOptions: ->
+    parentModel: @options.parentModel
+    listCollection: @options.listCollection
+
+  initialize: ->
+    { @type, @parentModel } = @options
+    @setEntityCreationData()
+    @collection = new Backbone.Collection()
+    @addCandidates()
+
+  serializeData: ->
+    parent: @parentModel.toJSON()
+    header: @options.header
+    createPath: @createPath
+
+  onShow: -> app.execute 'modal:open'
+
+  events:
+    'click .create': 'create'
+
+  setEntityCreationData: ->
+    { parentModel } = @
+    { type: parentType } = parentModel
+
+    claims = {}
+    prop = parentModel.childrenClaimProperty
+    claims[prop] = [ parentModel.get('uri') ]
+
+    if parentType is 'serie'
+      claims['wdt:P50'] = parentModel.get 'claims.wdt:P50'
+
+    else if parentType is 'collection'
+      claims['wdt:P123'] = parentModel.get 'claims.wdt:P123'
+
+    href = buildPath '/entity/new', { @type, claims }
+
+    @createPath = href
+    @_entityCreationData = { @type, claims }
+
+  addCandidates: ->
+    unless @parentModel.getChildrenCandidatesUris? then return
+
+    @parentModel.getChildrenCandidatesUris()
+    .then _.Log('childrenCandidatesUris')
+    .then (uris)-> app.request 'get:entities:models', { uris }
+    .then @collection.add.bind(@collection)
+
+  create: (e)->
+    if _.isOpenedOutside e then return
+    app.execute 'show:entity:create', @_entityCreationData
+    app.execute 'modal:close'

--- a/app/modules/entities/views/entities_list_adder.coffee
+++ b/app/modules/entities/views/entities_list_adder.coffee
@@ -14,13 +14,16 @@ module.exports = Marionette.CompositeView.extend
   childViewOptions: ->
     parentModel: @options.parentModel
     listCollection: @options.listCollection
+    childrenClaimProperty: @options.childrenClaimProperty
+
   emptyView: require 'modules/entities/views/editor/autocomplete_no_suggestion'
 
   ui:
     candidates: '.entitiesListElementCandidates'
 
   initialize: ->
-    { @type, @parentModel } = @options
+    { @type, @parentModel, @childrenClaimProperty } = @options
+    @childrenClaimProperty or= @parentModel.childrenClaimProperty
     @cantTypeSearch = @type in cantTypeSearch
     @setEntityCreationData()
     @collection = new PaginatedEntities null, { uris: [] }
@@ -47,7 +50,7 @@ module.exports = Marionette.CompositeView.extend
     { type: parentType } = parentModel
 
     claims = {}
-    prop = parentModel.childrenClaimProperty
+    prop = @childrenClaimProperty
     claims[prop] = [ parentModel.get('uri') ]
 
     if parentType is 'serie'

--- a/app/modules/entities/views/entities_list_adder.coffee
+++ b/app/modules/entities/views/entities_list_adder.coffee
@@ -83,7 +83,7 @@ module.exports = Marionette.CompositeView.extend
     @searchByType input
 
   searchByType: (input, initialCandidatesSearch)->
-    typeSearch @type, input
+    typeSearch @type, input, 50
     .then (results)=>
       # Ignore the results if the input changed
       if input isnt @_lastInput and not initialCandidatesSearch then return
@@ -99,6 +99,8 @@ module.exports = Marionette.CompositeView.extend
       label = @parentModel.get('label')
       @$el.addClass 'fetching'
       @_findCandidatesFromLabelSearch = true
+      # TODO: filter-out results that are likely bad suggestions
+      # such as an author's books, when we are looking for books *about* (wdt:P921) that author
       @searchByType label, true
 
   resetFromUris: (uris)->

--- a/app/modules/entities/views/entities_list_adder.coffee
+++ b/app/modules/entities/views/entities_list_adder.coffee
@@ -32,6 +32,7 @@ module.exports = Marionette.CompositeView.extend
 
   events:
     'click .create': 'create'
+    'click .done': _.clickCommand 'modal:close'
     'keydown #searchCandidates': 'lazySearch'
 
   setEntityCreationData: ->

--- a/app/modules/entities/views/entities_list_adder.coffee
+++ b/app/modules/entities/views/entities_list_adder.coffee
@@ -36,7 +36,7 @@ module.exports = Marionette.CompositeView.extend
     cantTypeSearch: @cantTypeSearch
 
   onShow: ->
-    app.execute 'modal:open'
+    app.execute 'modal:open', 'medium'
     # Doesn't work if set in events for some reason
     @ui.candidates.on 'scroll', @onScroll.bind(@)
 

--- a/app/modules/entities/views/entities_list_element_candidate.coffee
+++ b/app/modules/entities/views/entities_list_element_candidate.coffee
@@ -6,8 +6,7 @@ module.exports = Marionette.ItemView.extend
   template: require './templates/entities_list_element_candidate'
 
   initialize: ->
-    { parentModel, @listCollection } = @options
-    { @childrenClaimProperty } = parentModel
+    { parentModel, @listCollection, @childrenClaimProperty } = @options
     @parentUri = parentModel.get('uri')
     currentPropertyClaims = @model.get("claims.#{@childrenClaimProperty}")
     @alreadyAdded = @isAlreadyAdded()

--- a/app/modules/entities/views/entities_list_element_candidate.coffee
+++ b/app/modules/entities/views/entities_list_element_candidate.coffee
@@ -1,0 +1,23 @@
+module.exports = Marionette.ItemView.extend
+  className: 'entities-list-element-candidate'
+  template: require './templates/entities_list_element_candidate'
+  events:
+    'click .add': 'add'
+
+  add: ->
+    { parentModel, listCollection } = @options
+
+    listCollection.add @model
+
+    { childrenClaimProperty } = parentModel
+    uri = parentModel.get('uri')
+
+    @updateStatus()
+
+    @model.setPropertyValue childrenClaimProperty, null, uri
+    .then -> app.execute 'invalidate:entities:graph', uri
+
+  updateStatus: ->
+    # Use classes instead of a re-render to prevent blinking {{claim}} labels
+    @$el.find('.add').addClass 'hidden'
+    @$el.find('.added').removeClass 'hidden'

--- a/app/modules/entities/views/entities_list_element_candidate.coffee
+++ b/app/modules/entities/views/entities_list_element_candidate.coffee
@@ -11,7 +11,11 @@ module.exports = Marionette.ItemView.extend
     @alreadyAdded = currentPropertyClaims? and @parentUri in currentPropertyClaims
 
   serializeData: ->
-    _.extend @model.toJSON(),
+    attrs = @model.toJSON()
+    { type } = attrs
+    if type? then attrs[type] = true
+    attrs.description ?= _.i18n type
+    _.extend attrs,
       alreadyAdded: @alreadyAdded
 
   events:

--- a/app/modules/entities/views/entities_list_element_candidate.coffee
+++ b/app/modules/entities/views/entities_list_element_candidate.coffee
@@ -10,6 +10,7 @@ module.exports = Marionette.ItemView.extend
     @parentUri = parentModel.get('uri')
     currentPropertyClaims = @model.get("claims.#{@childrenClaimProperty}")
     @alreadyAdded = @isAlreadyAdded()
+    @invClaimValueOnWdEntity = parentModel.get('isInvEntity') and @model.get('isWikidataEntity')
 
   behaviors:
     AlertBox: {}
@@ -21,6 +22,7 @@ module.exports = Marionette.ItemView.extend
     attrs.description ?= _.i18n type
     _.extend attrs,
       alreadyAdded: @alreadyAdded
+      invClaimValueOnWdEntity: @invClaimValueOnWdEntity
 
   events:
     'click .add': 'add'

--- a/app/modules/entities/views/entities_list_element_candidate.coffee
+++ b/app/modules/entities/views/entities_list_element_candidate.coffee
@@ -1,4 +1,5 @@
 module.exports = Marionette.ItemView.extend
+  tagName: 'li'
   className: 'entities-list-element-candidate'
   template: require './templates/entities_list_element_candidate'
   events:

--- a/app/modules/entities/views/general_infobox.coffee
+++ b/app/modules/entities/views/general_infobox.coffee
@@ -1,6 +1,6 @@
 module.exports = Marionette.ItemView.extend
   className: 'generalInfobox'
-  template: require './templates/general_infobox'
+  template: require('./templates/general_infobox')
   behaviors:
     EntitiesCommons: {}
     ClampedExtract: {}

--- a/app/modules/entities/views/publisher_layout.coffee
+++ b/app/modules/entities/views/publisher_layout.coffee
@@ -1,6 +1,7 @@
 TypedEntityLayout = require './typed_entity_layout'
 EditionsList = require './editions_list'
 EntitiesList = require './entities_list'
+PaginatedEntities = require 'modules/entities/collections/paginated_entities'
 
 module.exports = TypedEntityLayout.extend
   id: 'publisherLayout'
@@ -25,18 +26,22 @@ module.exports = TypedEntityLayout.extend
     @showIsolatedEditions()
 
   showCollections: ->
+    uris = @model.publisherCollectionsUris
+    collection = new PaginatedEntities null, { uris, defaultType: 'collection' }
     @collectionsList.show new EntitiesList
       parentModel: @model
-      collection: @model.publisherCollections
+      collection: collection
       title: 'collections'
       type: 'collection'
       showActions: true
       compactMode: true
 
   showIsolatedEditions: ->
+    uris = @model.isolatedEditionsUris
+    collection = new PaginatedEntities null, { uris, defaultType: 'edition' }
     @editionsList.show new EntitiesList
       parentModel: @model
-      collection: @model.isolatedEditions
+      collection: collection
       title: 'editions'
       type: 'edition'
       showActions: true

--- a/app/modules/entities/views/publisher_layout.coffee
+++ b/app/modules/entities/views/publisher_layout.coffee
@@ -18,4 +18,4 @@ module.exports = TypedEntityLayout.extend
     .then @ifViewIsIntact('showEditions')
 
   showEditions: ->
-    @editionsList.show new EditionsList { collection: @model.editions }
+    @editionsList.show new EditionsList { collection: @model.editions, sortByLang: false }

--- a/app/modules/entities/views/publisher_layout.coffee
+++ b/app/modules/entities/views/publisher_layout.coffee
@@ -1,5 +1,6 @@
 TypedEntityLayout = require './typed_entity_layout'
 EditionsList = require './editions_list'
+EntitiesList = require './entities_list'
 
 module.exports = TypedEntityLayout.extend
   id: 'publisherLayout'
@@ -8,14 +9,35 @@ module.exports = TypedEntityLayout.extend
   Infobox: require './publisher_infobox'
   regions:
     infoboxRegion: '.publisherInfobox'
+    collectionsList: '#collectionsList'
     editionsList: '#editionsList'
     mergeSuggestionsRegion: '.mergeSuggestions'
 
+  initialize: ->
+    @model.initPublisherPublications()
+
   onShow: ->
-    unless @standalone? then return
+    @model.waitForPublications
+    .then @ifViewIsIntact('showPublications')
 
-    @model.fetchSubEntities @refresh
-    .then @ifViewIsIntact('showEditions')
+  showPublications: ->
+    @showCollections()
+    @showIsolatedEditions()
 
-  showEditions: ->
-    @editionsList.show new EditionsList { collection: @model.editions, sortByLang: false }
+  showCollections: ->
+    @collectionsList.show new EntitiesList
+      parentModel: @model
+      collection: @model.publisherCollections
+      title: 'collections'
+      type: 'collection'
+      showActions: true
+      compactMode: true
+
+  showIsolatedEditions: ->
+    @editionsList.show new EntitiesList
+      parentModel: @model
+      collection: @model.isolatedEditions
+      title: 'editions'
+      type: 'edition'
+      showActions: true
+      compactMode: true

--- a/app/modules/entities/views/publisher_layout.coffee
+++ b/app/modules/entities/views/publisher_layout.coffee
@@ -35,6 +35,7 @@ module.exports = TypedEntityLayout.extend
       type: 'collection'
       showActions: true
       compactMode: true
+      addButtonLabel: 'add a collection from this publisher'
 
   showIsolatedEditions: ->
     uris = @model.isolatedEditionsUris
@@ -46,3 +47,4 @@ module.exports = TypedEntityLayout.extend
       type: 'edition'
       showActions: true
       compactMode: true
+      addButtonLabel: 'add an edition from this publisher'

--- a/app/modules/entities/views/serie_layout.coffee
+++ b/app/modules/entities/views/serie_layout.coffee
@@ -36,3 +36,4 @@ module.exports = TypedEntityLayout.extend
       type: 'work'
       hideHeader: true
       refresh: @refresh
+      addButtonLabel: 'add a work to this serie'

--- a/app/modules/entities/views/templates/collection_infobox.hbs
+++ b/app/modules/entities/views/templates/collection_infobox.hbs
@@ -5,13 +5,12 @@
   </div>
 {{/if}}
 <div class="collectionData text-center entity-data-box">
-  <h3 class="showEntity">{{label}}</h3>
+  {{#if standalone}}
+    <h2>{{label}}</h2>
+  {{else}}
+    <h3><a href="{{pathname}}" class="showEntity link">{{label}}</a></h3>
+  {{/if}}
   <h4 class="subheader">{{shortDescription}}</h4>
-  {{!-- hidden class overriden by --}}
-  {{!-- modules/entities/scss/_deduplicate.scss --}}
-  {{!-- modules/tasks/scss/_current_task.scss --}}
-  <span class="uri hidden">{{uri}}</span>
-
   <div class='wiki-attributes'>
     <p class="claims">
       {{stringClaim claims 'wdt:P1680'}}  {{!-- subtitle --}}

--- a/app/modules/entities/views/templates/collection_infobox.hbs
+++ b/app/modules/entities/views/templates/collection_infobox.hbs
@@ -1,0 +1,26 @@
+{{#if image.url}}
+  <div class="image-wrapper">
+    <img src="{{imgSrc image.url 300}}" alt="{{label}} cover">
+    {{partial 'entities:photo_credits' image.credits}}
+  </div>
+{{/if}}
+<div class="collectionData text-center entity-data-box">
+  <h3 class="showEntity">{{label}}</h3>
+  <h4 class="subheader">{{shortDescription}}</h4>
+  {{!-- hidden class overriden by --}}
+  {{!-- modules/entities/scss/_deduplicate.scss --}}
+  {{!-- modules/tasks/scss/_current_task.scss --}}
+  <span class="uri hidden">{{uri}}</span>
+
+  <div class='wiki-attributes'>
+    <p class="claims">
+      {{stringClaim claims 'wdt:P1680'}}  {{!-- subtitle --}}
+      {{claim claims 'wdt:P123' true}} {{!-- publisher --}}
+      {{claim claims 'wdt:P98' true}}  {{!-- editor --}}
+      {{urlClaim claims 'wdt:P856'}} {{!-- official website --}}
+    </p>
+  </div>
+
+  {{partial 'entities:clamped_extract' this}}
+  {{partial 'entities:edit_data' this}}
+</div>

--- a/app/modules/entities/views/templates/collection_layout.hbs
+++ b/app/modules/entities/views/templates/collection_layout.hbs
@@ -1,4 +1,6 @@
-<h3 class="layout-type-label">{{I18n 'collection'}}</h3>
+{{#if standalone}}
+  <h3 class="layout-type-label">{{I18n 'collection'}}</h3>
+{{/if}}
 <div class='collectionInfobox'></div>
 <div id="editionsList"></div>
 {{#if standalone}}

--- a/app/modules/entities/views/templates/collection_layout.hbs
+++ b/app/modules/entities/views/templates/collection_layout.hbs
@@ -1,0 +1,7 @@
+<h3 class="layout-type-label">{{I18n 'collection'}}</h3>
+<div class='collectionInfobox'></div>
+<div id="editionsList"></div>
+{{#if standalone}}
+  {{partial 'entities:merge_suggestions_layout_section' this}}
+  {{partial 'welcome:embedded_welcome'}}
+{{/if}}

--- a/app/modules/entities/views/templates/edit_data.hbs
+++ b/app/modules/entities/views/templates/edit_data.hbs
@@ -3,12 +3,12 @@
     <a href="{{edit}}" class="showEntityEdit pencil" title="{{i18n 'edit data'}}">
       {{icon 'pencil'}}
     </a>
-    {{#if wikidata}}
-      {{iconLink 'wikidata' wikidata.url i18n='see on Wikidata' linkClasses='showOnWikidata'}}
-      {{#unless hideRefreshButton}}
-        <a class="refreshEntityData" title="{{i18n 'refresh Wikidata data'}}">{{icon 'refresh'}}</a>
-      {{/unless}}
-    {{/if}}
+  {{/if}}
+  {{#if wikidata}}
+    {{iconLink 'wikidata' wikidata.url i18n='see on Wikidata' linkClasses='showOnWikidata'}}
+    {{#unless hideRefreshButton}}
+      <a class="refreshEntityData" title="{{i18n 'refresh Wikidata data'}}">{{icon 'refresh'}}</a>
+    {{/unless}}
   {{/if}}
   {{#if showDeduplicateEntityButton}}
     <a class="deduplicateSubEntities" title="{{i18n 'deduplicate sub-entities'}}">{{icon 'compress'}}</a>

--- a/app/modules/entities/views/templates/edition_claims.hbs
+++ b/app/modules/entities/views/templates/edition_claims.hbs
@@ -14,7 +14,7 @@
     {{claim claims 'wdt:P655'}} {{!-- translator --}}
     {{claim claims 'wdt:P407'}} {{!-- edition language --}}
     {{claim claims 'wdt:P123' true}} {{!-- publisher --}}
-    {{claim claims 'wdt:P195'}} {{!-- collection --}}
+    {{claim claims 'wdt:P195' true}} {{!-- collection --}}
     {{timeClaim claims 'wdt:P577'}} {{!-- publication date --}}
   </p>
   {{!-- not so important for most users --}}

--- a/app/modules/entities/views/templates/edition_li.hbs
+++ b/app/modules/entities/views/templates/edition_li.hbs
@@ -19,7 +19,9 @@
     </div>
   </div>
 </div>
-<div class="editionEntityActions"></div>
-<div class="items">
-  {{partial 'entities:items_lists' prefix='edition' disabled=itemUpdateContext}}
-</div>
+{{#unless compactMode}}
+  <div class="editionEntityActions"></div>
+  <div class="items">
+    {{partial 'entities:items_lists' prefix='edition' disabled=itemsListsDisabled}}
+  </div>
+{{/unless}}

--- a/app/modules/entities/views/templates/editions_list.hbs
+++ b/app/modules/entities/views/templates/editions_list.hbs
@@ -1,13 +1,15 @@
 <h3>{{i18n header}}</h3>
-{{#if hasEditions}}
-  <div class="filters">
-    <select class="languageFilter" name="language-filter">
-      <option value="all">{{i18n 'all languages'}}</option>
-      {{#each availableLanguages}}
-        <option value="{{code}}" {{#if selected}}selected{{/if}}>{{code}} - {{native}}</option>
-      {{/each}}
-    </select>
-  </div>
+{{#if sortByLang}}
+  {{#if hasEditions}}
+    <div class="filters">
+      <select class="languageFilter" name="language-filter">
+        <option value="all">{{i18n 'all languages'}}</option>
+        {{#each availableLanguages}}
+          <option value="{{code}}" {{#if selected}}selected{{/if}}>{{code}} - {{native}}</option>
+        {{/each}}
+      </select>
+    </div>
+  {{/if}}
 {{/if}}
 <ul></ul>
 {{! publisher editions list work is undefined }}

--- a/app/modules/entities/views/templates/editions_list.hbs
+++ b/app/modules/entities/views/templates/editions_list.hbs
@@ -1,4 +1,4 @@
-<h3>{{i18n header}}</h3>
+{{#if header}}<h3>{{i18n header}}</h3>{{/if}}
 {{#if sortByLang}}
   {{#if hasEditions}}
     <div class="filters">

--- a/app/modules/entities/views/templates/entities_list.hbs
+++ b/app/modules/entities/views/templates/entities_list.hbs
@@ -13,7 +13,7 @@
     </a>
   {{/if}}
   {{#if addOneLabel}}
-    <a class="addOne {{#if more}}hidden{{/if}}">
+    <a class="addOne">
       {{icon 'plus'}}{{i18n addOneLabel}}
     </a>
   {{/if}}

--- a/app/modules/entities/views/templates/entities_list.hbs
+++ b/app/modules/entities/views/templates/entities_list.hbs
@@ -7,14 +7,14 @@
 <div class="container"></div>
 <div class="works-list-controls">
   {{#if more}}
-    <a class="displayMore">
+    <button class="displayMore">
       {{icon 'chevron-down'}}{{i18n 'display more'}}
       <span class="counter">{{more}}</span>
-    </a>
+    </button>
   {{/if}}
-  {{#if addOneLabel}}
-    <a class="addOne">
-      {{icon 'plus'}}{{i18n addOneLabel}}
-    </a>
+  {{#if addButtonLabel}}
+    <button class="addOne">
+      {{icon 'plus'}}{{i18n addButtonLabel}}
+    </button>
   {{/if}}
 </div>

--- a/app/modules/entities/views/templates/entities_list.hbs
+++ b/app/modules/entities/views/templates/entities_list.hbs
@@ -12,9 +12,9 @@
       <span class="counter">{{more}}</span>
     </a>
   {{/if}}
-  {{#if addOne}}
-    <a href="{{addOne.href}}" class="addOne {{#if more}}hidden{{/if}}">
-      {{icon 'plus'}}{{i18n addOne.label}}
+  {{#if addOneLabel}}
+    <a class="addOne {{#if more}}hidden{{/if}}">
+      {{icon 'plus'}}{{i18n addOneLabel}}
     </a>
   {{/if}}
 </div>

--- a/app/modules/entities/views/templates/entities_list_adder.hbs
+++ b/app/modules/entities/views/templates/entities_list_adder.hbs
@@ -1,0 +1,9 @@
+<h3 class="parent-label">{{parent.label}}</h3>
+<p class="context">{{I18n header}}</p>
+<div>
+  <input type="text" placeholder="{{I18n 'search_verb'}}...">
+</div>
+
+<div class="entitiesListElementCandidates"></div>
+
+<a href="{{createPath}}" class="create tiny-button light-blue">{{icon 'plus'}}{{I18n 'create'}}</a>

--- a/app/modules/entities/views/templates/entities_list_adder.hbs
+++ b/app/modules/entities/views/templates/entities_list_adder.hbs
@@ -6,6 +6,8 @@
 
 <ul class="entitiesListElementCandidates"></ul>
 
+{{partial 'loader'}}
+
 <div class="buttons">
   <a href="{{createPath}}" class="create tiny-button light-blue">{{icon 'plus'}}{{I18n 'create'}}</a>
   <a class="done tiny-button">{{icon 'check'}}{{I18n 'done'}}</a>

--- a/app/modules/entities/views/templates/entities_list_adder.hbs
+++ b/app/modules/entities/views/templates/entities_list_adder.hbs
@@ -1,9 +1,9 @@
 <h3 class="parent-label">{{parent.label}}</h3>
 <p class="context">{{I18n header}}</p>
-<div>
-  <input type="text" placeholder="{{I18n 'search_verb'}}...">
-</div>
+{{#unless cantTypeSearch}}
+  <input id="searchCandidates" type="text" placeholder="{{I18n 'search_verb'}}...">
+{{/unless}}
 
-<div class="entitiesListElementCandidates"></div>
+<ul class="entitiesListElementCandidates"></ul>
 
 <a href="{{createPath}}" class="create tiny-button light-blue">{{icon 'plus'}}{{I18n 'create'}}</a>

--- a/app/modules/entities/views/templates/entities_list_adder.hbs
+++ b/app/modules/entities/views/templates/entities_list_adder.hbs
@@ -6,4 +6,7 @@
 
 <ul class="entitiesListElementCandidates"></ul>
 
-<a href="{{createPath}}" class="create tiny-button light-blue">{{icon 'plus'}}{{I18n 'create'}}</a>
+<div class="buttons">
+  <a href="{{createPath}}" class="create tiny-button light-blue">{{icon 'plus'}}{{I18n 'create'}}</a>
+  <a class="done tiny-button">{{icon 'check'}}{{I18n 'done'}}</a>
+</div>

--- a/app/modules/entities/views/templates/entities_list_element_candidate.hbs
+++ b/app/modules/entities/views/templates/entities_list_element_candidate.hbs
@@ -30,4 +30,5 @@
 <div class="status">
   <a class="tiny-button light-blue add {{#if alreadyAdded}}hidden{{/if}}">{{icon 'plus'}} {{i18n 'add'}}</a>
   <span class="added {{#unless alreadyAdded}}hidden{{/unless}}">{{icon 'check'}} {{i18n 'added'}}</span>
+  <div class="has-alertbox"></div>
 </div>

--- a/app/modules/entities/views/templates/entities_list_element_candidate.hbs
+++ b/app/modules/entities/views/templates/entities_list_element_candidate.hbs
@@ -1,10 +1,12 @@
 <a href="{{pathname}}" class="showEntity">
   {{#if image.url}}
-    <img src="{{imgSrc image.url 200}}" alt="{{label}}">
+    <div class="image-wrapper">
+      <img src="{{imgSrc image.url 200}}" alt="{{label}}">
+    </div>
   {{/if}}
   <div class="info">
-    <span class="label">{{label}}</span>
-    <span class="description">{{description}}</span>
+    <p class="label">{{label}}</p>
+    <p class="description">{{description}}</p>
     <div class="claims">
       {{claim claims 'wdt:P50'}}  {{!-- author --}}
       {{claim claims 'wdt:P58'}} {{!-- scenarist --}}

--- a/app/modules/entities/views/templates/entities_list_element_candidate.hbs
+++ b/app/modules/entities/views/templates/entities_list_element_candidate.hbs
@@ -12,10 +12,17 @@
       {{claim claims 'wdt:P58'}} {{!-- scenarist --}}
       {{claim claims 'wdt:P110'}} {{!-- illustrator --}}
       {{claim claims 'wdt:P6338'}} {{!-- colorist --}}
-      {{claim claims 'wdt:P123'}} {{!-- publisher --}}
-      {{claim claims 'wdt:P195'}} {{!-- collection --}}
+      {{#if edition}}
+        {{claim claims 'wdt:P123'}} {{!-- publisher --}}
+        {{claim claims 'wdt:P195'}} {{!-- collection --}}
+        {{claim claims 'wdt:P98'}} {{!-- editor --}}
+      {{/if}}
+      {{#if collection}}
+        {{claim claims 'wdt:P123'}} {{!-- publisher --}}
+        {{claim claims 'wdt:P98'}} {{!-- editor --}}
+      {{/if}}
       {{timeClaim claims 'wdt:P577'}} {{!-- publication date --}}
-      {{claim claims 'wdt:P407'}} {{!-- edition language --}}
+      {{claim claims 'wdt:P407'}} {{!-- language --}}
     </div>
   </div>
 </a>

--- a/app/modules/entities/views/templates/entities_list_element_candidate.hbs
+++ b/app/modules/entities/views/templates/entities_list_element_candidate.hbs
@@ -1,0 +1,24 @@
+<a href="{{pathname}}" class="showEntity">
+  {{#if image.url}}
+    <img src="{{imgSrc image.url 200}}" alt="{{label}}">
+  {{/if}}
+  <div class="info">
+    <span class="label">{{label}}</span>
+    <span class="description">{{description}}</span>
+    <div class="claims">
+      {{claim claims 'wdt:P50'}}  {{!-- author --}}
+      {{claim claims 'wdt:P58'}} {{!-- scenarist --}}
+      {{claim claims 'wdt:P110'}} {{!-- illustrator --}}
+      {{claim claims 'wdt:P6338'}} {{!-- colorist --}}
+      {{claim claims 'wdt:P123'}} {{!-- publisher --}}
+      {{claim claims 'wdt:P195'}} {{!-- collection --}}
+      {{timeClaim claims 'wdt:P577'}} {{!-- publication date --}}
+      {{claim claims 'wdt:P407'}} {{!-- edition language --}}
+    </div>
+  </div>
+</a>
+
+<div class="status">
+  <a class="tiny-button light-blue add">{{icon 'plus'}} {{i18n 'add'}}</a>
+  <span class="added hidden">{{icon 'check'}} {{i18n 'added'}}</span>
+</div>

--- a/app/modules/entities/views/templates/entities_list_element_candidate.hbs
+++ b/app/modules/entities/views/templates/entities_list_element_candidate.hbs
@@ -21,6 +21,6 @@
 </a>
 
 <div class="status">
-  <a class="tiny-button light-blue add">{{icon 'plus'}} {{i18n 'add'}}</a>
-  <span class="added hidden">{{icon 'check'}} {{i18n 'added'}}</span>
+  <a class="tiny-button light-blue add {{#if alreadyAdded}}hidden{{/if}}">{{icon 'plus'}} {{i18n 'add'}}</a>
+  <span class="added {{#unless alreadyAdded}}hidden{{/unless}}">{{icon 'check'}} {{i18n 'added'}}</span>
 </div>

--- a/app/modules/entities/views/templates/entities_list_element_candidate.hbs
+++ b/app/modules/entities/views/templates/entities_list_element_candidate.hbs
@@ -28,7 +28,11 @@
 </a>
 
 <div class="status">
-  <a class="tiny-button light-blue add {{#if alreadyAdded}}hidden{{/if}}">{{icon 'plus'}} {{i18n 'add'}}</a>
-  <span class="added {{#unless alreadyAdded}}hidden{{/unless}}">{{icon 'check'}} {{i18n 'added'}}</span>
-  <div class="has-alertbox"></div>
+  {{#if invClaimValueOnWdEntity}}
+    <p class="warning">{{I18n "wikidata entities can't link to inventaire entities"}}</p>
+  {{else}}
+    <a class="tiny-button light-blue add {{#if alreadyAdded}}hidden{{/if}}">{{icon 'plus'}} {{i18n 'add'}}</a>
+    <span class="added {{#unless alreadyAdded}}hidden{{/unless}}">{{icon 'check'}} {{i18n 'added'}}</span>
+    <div class="has-alertbox"></div>
+  {{/if}}
 </div>

--- a/app/modules/entities/views/templates/general_infobox.hbs
+++ b/app/modules/entities/views/templates/general_infobox.hbs
@@ -10,10 +10,11 @@
     {{/if}}
   </a>
 {{/if}}
-<div class="data">
+<div class="entity-data-box">
   <h2><a class="showEntity link" href="{{pathname}}">{{label}}</a></h2>
   <h3 class="subheader">{{description}}</h3>
   {{#if extract}}
     <p class="extract" dir="{{extractDirection}}">{{{extract}}}</p>
   {{/if}}
+  {{partial 'entities:edit_data' this}}
 </div>

--- a/app/modules/entities/views/templates/publisher_layout.hbs
+++ b/app/modules/entities/views/templates/publisher_layout.hbs
@@ -1,5 +1,6 @@
 <h3 class="layout-type-label">{{I18n 'publisher'}}</h3>
 <div class='publisherInfobox'></div>
+<div id="collectionsList"></div>
 <div id="editionsList"></div>
 {{#if standalone}}
   {{partial 'entities:merge_suggestions_layout_section' this}}

--- a/app/modules/general/scss/_modal.scss
+++ b/app/modules/general/scss/_modal.scss
@@ -28,11 +28,11 @@ body.openedModal{
   &.modal-large{ max-width: $largeModalWidth; }
   .close{
     line-height: 0;
-    font-size: 2.8em;
+    font-size: 3.6rem;
     font-weight: bold;
     color: white;
-    @include shy(0.5);
-    @include position(absolute, 40px, 0);
+    @include shy(0.8);
+    @include position(absolute, 2.6rem, 0);
   }
   /*Small screens*/
   @media screen and (max-width: $small-screen) {
@@ -47,9 +47,9 @@ body.openedModal{
   }
   /*Medium / Large screens*/
   @media screen and (min-width: $smaller-screen) {
+    // Important for the place of the .close button
     padding: 2em;
-    min-width: 35em;
-    margin-top: 50px;
+    min-width: 40em;
   }
   /*Large screens*/
   @media screen and (min-width: $small-screen) {

--- a/app/modules/search/models/result.coffee
+++ b/app/modules/search/models/result.coffee
@@ -17,6 +17,8 @@ typeFormatters =
   works: entityFormatter 'work', 'book'
   humans: entityFormatter 'author'
   series: entityFormatter 'serie'
+  collections: entityFormatter 'collection'
+  publishers: entityFormatter 'publisher'
   users: (data)->
     data.typeAlias = 'user'
     # label is the username

--- a/app/modules/search/scss/_live_search.scss
+++ b/app/modules/search/scss/_live_search.scss
@@ -1,15 +1,16 @@
 #live-search{
   flex: 1 0 auto;
   .resultsWrapper, .sections{
-    background-color: white;
+    background-color: #eee;
   }
   .sections{
-    @include display-flex(row, flex-end, space-around);
+    @include display-flex(row, flex-end, flex-start, wrap);
     text-align: center;
+    overflow-x: auto;
   }
   .searchSection{
-    flex: 1 0 0;
-    min-width: 4em;
+    flex: 1 0 6em;
+    max-width: 8em;
     padding: 0.5em 0.2em;
     background-color: #f3f3f3;
     @include transition(background-color);
@@ -159,16 +160,12 @@
   @media screen and (max-width: $smaller-screen) {
     height: 100%;
     @include display-flex(column);
-    .sections{
-      overflow: auto;
-      @include display-flex(row, center, flex-start);
-      flex: 0 0 auto;
-    }
-    .searchSection{
-      flex: 1 0 auto;
-    }
     .propositions{
       justify-content: center;
+    }
+    .sections{
+      flex: 0 0 auto;
+      border-top: 1px solid #ccc;
     }
   }
 

--- a/app/modules/search/search.coffee
+++ b/app/modules/search/search.coffee
@@ -57,7 +57,7 @@ showEntityPageIfUri = (query, refresh)->
   else
     return false
 
-sectionSearchPattern = /^!([blwahsugt])\s+/
+sectionSearchPattern = /^!([a-z])\s+/
 
 findSearchSection = (q)->
   sectionMatch = q.match(sectionSearchPattern)?[1]
@@ -67,19 +67,18 @@ findSearchSection = (q)->
 
   firstLetter = sectionMatch[0]
   section = sections[firstLetter] or 'all'
+  console.log 'section', section
   return [ q, section ]
 
 sections =
-  b: 'book'
-  # 'l' for livre, libro, liber
-  l: 'book'
-  # 'w' for work
-  w: 'book'
   a: 'author'
-  # 'h' for human
-  h: 'author'
-  s: 'serie'
-  u: 'user'
+  b: 'book'
+  c: 'collection'
   g: 'group'
-  # 't' for topic (as series already use the 's')
-  t: 'subject'
+  h: 'author' # 'h' for human
+  l: 'book' # 'l' for livre, libro, liber
+  p: 'publisher'
+  s: 'serie'
+  t: 'subject' # 't' for topic (as series already use the 's')
+  u: 'user'
+  w: 'book' # 'w' for work

--- a/app/modules/search/views/live_search.coffee
+++ b/app/modules/search/views/live_search.coffee
@@ -92,8 +92,8 @@ module.exports = Marionette.CompositeView.extend
 
     @updateAlternatives type
 
-  updateAlternatives: (type)->
-    if type in sectionsWithAlternatives then @showAlternatives()
+  updateAlternatives: (search)->
+    if @_lastType in sectionsWithAlternatives then @showAlternatives(search)
     else @hideAlternatives()
 
   search: (search)->
@@ -111,7 +111,7 @@ module.exports = Marionette.CompositeView.extend
     .then @resetResults.bind(@, @_lastSearchId)
 
     @_waitingForAlternatives = true
-    @setTimeout @showAlternatives.bind(@, search), 2000
+    @setTimeout @updateAlternatives.bind(@, search), 2000
 
   _search: (search)->
     types = @getTypes()
@@ -267,7 +267,7 @@ sectionToTypes =
   user: 'users'
   group: 'groups'
 
-sectionsWithAlternatives = [ 'all', 'book', 'author', 'serie' ]
+sectionsWithAlternatives = [ 'all', 'book', 'author', 'serie', 'collection', 'publisher' ]
 
 getTypeFromId = (id)-> id.replace 'section-', ''
 
@@ -296,8 +296,8 @@ sectionsData = ->
   book: { label: 'book' }
   author: { label: 'author' }
   serie: { label: 'series_singular' }
+  user: { label: 'user' }
+  group: { label: 'group' }
   publisher: { label: 'publisher' }
   collection: { label: 'collection' }
   subject: { label: 'subject' }
-  user: { label: 'user' }
-  group: { label: 'group' }

--- a/app/modules/search/views/live_search.coffee
+++ b/app/modules/search/views/live_search.coffee
@@ -40,8 +40,10 @@ module.exports = Marionette.CompositeView.extend
 
   serializeData: ->
     sections = sectionsData()
-    selectedSectionName = if sections[@selectedSectionName]? then @selectedSectionName else 'all'
-    sections[selectedSectionName].selected = true
+    unless sections[@selectedSectionName]?
+      _.warn { sections, @selectedSectionName }, 'unknown search section'
+      @selectedSectionName = 'all'
+    sections[@selectedSectionName].selected = true
     return { sections }
 
   events:
@@ -255,13 +257,15 @@ module.exports = Marionette.CompositeView.extend
     @collection.add newResults
 
 sectionToTypes =
-  all: [ 'works', 'humans', 'series', 'users', 'groups' ]
+  all: [ 'works', 'humans', 'series', 'publishers', 'collections', 'users', 'groups' ]
   book: 'works'
   author: 'humans'
   serie: 'series'
+  collection: 'collections'
+  publisher: 'publishers'
+  subject: 'subjects'
   user: 'users'
   group: 'groups'
-  subject: 'subjects'
 
 sectionsWithAlternatives = [ 'all', 'book', 'author', 'serie' ]
 
@@ -292,6 +296,8 @@ sectionsData = ->
   book: { label: 'book' }
   author: { label: 'author' }
   serie: { label: 'series_singular' }
+  publisher: { label: 'publisher' }
+  collection: { label: 'collection' }
+  subject: { label: 'subject' }
   user: { label: 'user' }
   group: { label: 'group' }
-  subject: { label: 'subject' }

--- a/app/modules/shelves/scss/_shelf_items_adder.scss
+++ b/app/modules/shelves/scss/_shelf_items_adder.scss
@@ -9,13 +9,9 @@
     align-self: stretch;
     button{
       padding: 0.7em;
-
       text-align: center;
       flex: 1;
       font-weight: bold;
-    }
-    .done{
-      margin-left: 0.5em;
     }
     .addNewItems{
       padding: 0.7em 0.6em;
@@ -30,6 +26,33 @@
     .centered-loader{
       color: $grey;
       display: none;
+    }
+  }
+  /*Very Small screens*/
+  @media screen and (max-width: $smaller-screen) {
+    .shelf-items-candidate{
+      @include display-flex(column, center, center);
+    }
+    .showItem{
+      @include display-flex(column, center, center);
+    }
+    .buttons{
+      padding: 0 1em;
+      flex-direction: column;
+      align-items: stretch;
+      .addNewItems{
+        margin-bottom: 1em;
+      }
+    }
+  }
+
+  /*Large screens*/
+  @media screen and (min-width: $smaller-screen) {
+    .done{
+      margin-left: 0.5em;
+    }
+    .status{
+      margin-left: auto;
     }
   }
 }
@@ -64,7 +87,6 @@
   }
   .title, .authors{
     margin-right: 0.5em;
-    white-space: nowrap;
     flex: 0 0 auto;
   }
   .title{
@@ -88,21 +110,4 @@
 
 #searchCandidates{
   max-width: 20em;
-}
-
-/*Very Small screens*/
-@media screen and (max-width: $very-small-screen) {
-  .shelf-items-candidate{
-    @include display-flex(column, center, center);
-  }
-  .showItem{
-    @include display-flex(column, center, center);
-  }
-}
-
-/*Large screens*/
-@media screen and (min-width: $very-small-screen) {
-  .status{
-    margin-left: auto;
-  }
 }


### PR DESCRIPTION
associated with server PR https://github.com/inventaire/inventaire/pull/407

* adds a layout for collections
* make publishers and collections searchable from live search bar
* update the publisher layout to display collections
* repurpose the "add a {entity type} to this {parent entity type}" button:
  * before: directly display an entity draft editor to create a new entity
  * after: displays suggestions when available and a search bar when possible, to add to the list with a single click