### PR TITLE
disable piwik/matomo cookies for all users

### DIFF
--- a/app/lib/piwik.js
+++ b/app/lib/piwik.js
@@ -25,6 +25,7 @@ export default async function () {
   const trackerUrl = env === 'dev' ? app.API.tests : `${piwik}/piwik.php`
 
   _paq.push([ 'enableLinkTracking' ])
+  _paq.push([ 'disableCookies' ]) // See https://matomo.org/faq/general/faq_156/
   _paq.push([ 'setTrackerUrl', trackerUrl ])
   _paq.push([ 'setSiteId', '11' ])
 


### PR DESCRIPTION
Analytics cookies aren't strictly required to provide the service and thus should require, under GDPR, to request the user's consent. It's easier to just get rid of them rather than to implement some of those annoying cookie consent box. The [impact on analytics accuracy](https://matomo.org/faq/general/faq_156/) seems very acceptable, given our use case.

Next action: update [privacy statement](https://wiki.inventaire.io/wiki/Privacy)