### PR TITLE
use node-config to allow customization of the webpack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ issues
 vendor/piwik.js
 scripts/assets/bundles_stats/
 scripts/assets/bundles_archives/
+config/local.cjs

--- a/bundle/dev_server.cjs
+++ b/bundle/dev_server.cjs
@@ -1,4 +1,5 @@
 const path = require('path')
+const { inventaireServerHost } = require('config')
 
 module.exports = {
   host: '0.0.0.0',
@@ -9,9 +10,9 @@ module.exports = {
   overlay: true,
   // See https://webpack.js.org/configuration/dev-server/#devserverproxy
   proxy: {
-    '/api': 'http://localhost:3006',
-    '/public': 'http://localhost:3006',
-    '/img': 'http://localhost:3006',
+    '/api': inventaireServerHost,
+    '/public': inventaireServerHost,
+    '/img': inventaireServerHost,
   },
   historyApiFallback: {
     rewrites: [

--- a/bundle/webpack.config.dev.cjs
+++ b/bundle/webpack.config.dev.cjs
@@ -1,7 +1,7 @@
 const mode = 'development'
-const config = require('./webpack.config.common.cjs')(mode)
+const webpackConfig = require('./webpack.config.common.cjs')(mode)
 
-Object.assign(config, {
+Object.assign(webpackConfig, {
   mode,
   // Override 'browserlist' value (deduced from the presence of a browserslist in package.json)
   // as that disables HMR, see https://github.com/webpack/webpack-dev-server/issues/2758
@@ -10,4 +10,4 @@ Object.assign(config, {
   devServer: require('./dev_server.cjs')
 })
 
-module.exports = config
+module.exports = webpackConfig

--- a/bundle/webpack.config.prod.cjs
+++ b/bundle/webpack.config.prod.cjs
@@ -1,17 +1,17 @@
 const mode = 'production'
-const config = require('./webpack.config.common.cjs')(mode)
+const webpackConfig = require('./webpack.config.common.cjs')(mode)
 
-Object.assign(config, {
+Object.assign(webpackConfig, {
   mode,
   devtool: 'source-map',
   target: 'browserslist',
 })
 
-config.output.filename = '[name].[contenthash:8].js'
+webpackConfig.output.filename = '[name].[contenthash:8].js'
 
-config.plugins.push(require('./plugins/detect_circular_dependencies.cjs'))
-config.plugins.push(require('./plugins/detect_unused_files.cjs'))
-config.plugins.push(require('./plugins/bundle_analyzer.cjs'))
-config.optimization = require('./optimization.cjs')
+webpackConfig.plugins.push(require('./plugins/detect_circular_dependencies.cjs'))
+webpackConfig.plugins.push(require('./plugins/detect_unused_files.cjs'))
+webpackConfig.plugins.push(require('./plugins/bundle_analyzer.cjs'))
+webpackConfig.optimization = require('./optimization.cjs')
 
-module.exports = config
+module.exports = webpackConfig

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  inventaireServerHost: 'http://localhost:3006'
+}

--- a/config/default.js
+++ b/config/default.js
@@ -1,9 +1,0 @@
-export default {
-  // transifex doesn't use API keys or anything, just the same credentials as for an in browser login
-  transifex: {
-    username: 'customize',
-    password: 'customize'
-  },
-  host: 'http://localhost:3006',
-  prerenderUrl: 'http://localhost:3000',
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2392,6 +2392,13 @@
         "backbone.babysitter": "^0.1.0",
         "backbone.wreqr": "^1.0.0",
         "underscore": "1.4.4 - 1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+        }
       }
     },
     "backbone.wreqr": {
@@ -3191,12 +3198,22 @@
       "dev": true
     },
     "config": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.31.0.tgz",
-      "integrity": "sha512-Ep/l9Rd1J9IPueztJfpbOqVzuKHQh4ZODMNt9xqTYdBBNRXbV4oTu34kCkkfdRVcDq0ohtpaeXGgb+c0LQxFRA==",
+      "version": "git+https://github.com/lorenwest/node-config.git#b4ba63c84ec9b3d86559bca05b34f78833f3f850",
+      "from": "git+https://github.com/lorenwest/node-config.git#b4ba63c8",
       "dev": true,
       "requires": {
-        "json5": "^1.0.1"
+        "json5": "^2.1.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "connect-history-api-fallback": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/runtime": "^7.12.0",
     "babel-loader": "^8.1.0",
     "circular-dependency-plugin": "^5.2.0",
-    "config": "^1.31.0",
+    "config": "git+https://github.com/lorenwest/node-config.git#b4ba63c8",
     "css-loader": "^5.0.0",
     "cssnano": "^4.1.10",
     "doctoc": "^1.4.0",


### PR DESCRIPTION
[node-config](https://github.com/lorenwest/node-config) is heavily used on the server-side, less on the client side, but that could be a good use case to reuse this familiar setup

Using a to-be-released version of node-config to benefit from [support of .cjs files](https://github.com/lorenwest/node-config/commit/8acffa795b139c3fd206334678b54b59e7eab6a7)

Addressing https://github.com/inventaire/inventaire-client/issues/241