### PR TITLE
live search sections

### DIFF
--- a/app/modules/general/scss/_top_bar.scss
+++ b/app/modules/general/scss/_top_bar.scss
@@ -1,4 +1,4 @@
-$search-section-width: 6em;
+$search-section-width-on-large-screen: 6em;
 
 nav#top-bar{
   // Use position:fixed to make the top-bar stick to the screen top
@@ -44,7 +44,7 @@ nav#top-bar{
   #searchGroup{
     flex: 1 0 auto;
     // 7 = max number of search section on a row
-    max-width: 7 * $search-section-width;
+    max-width: 7 * $search-section-width-on-large-screen;
     margin: 0 auto;
     margin-bottom: 0;
   }

--- a/app/modules/general/scss/_top_bar.scss
+++ b/app/modules/general/scss/_top_bar.scss
@@ -1,3 +1,5 @@
+$search-section-width: 6em;
+
 nav#top-bar{
   // Use position:fixed to make the top-bar stick to the screen top
   @include position(fixed, 0, 0, null, 0, 15);
@@ -41,7 +43,8 @@ nav#top-bar{
   }
   #searchGroup{
     flex: 1 0 auto;
-    max-width: 40em;
+    // 7 = max number of search section on a row
+    max-width: 7 * $search-section-width;
     margin: 0 auto;
     margin-bottom: 0;
   }
@@ -61,7 +64,7 @@ nav#top-bar{
     }
   }
   #liveSearch{
-    @include position(absolute, 100%, 1px, null, 0);
+    @include position(absolute, 100%, 0, null, 0);
     &:not(.shown){
       top: -100vh;
       bottom: 100vh;
@@ -165,3 +168,4 @@ nav#top-bar{
 
 @import 'top_bar_language_picker';
 @import 'top_bar_buttons';
+@import '../../search/scss/live_search';

--- a/app/modules/general/scss/base.scss
+++ b/app/modules/general/scss/base.scss
@@ -30,7 +30,6 @@
 @import 'app_layout';
 @import '../../network/scss/network';
 @import '../../inventory/scss/inventory';
-@import '../../search/scss/live_search';
 @import '../../entities/scss/entities';
 @import '../../notifications/scss/notifications';
 @import '../../map/scss/map';

--- a/app/modules/inventory/views/add/templates/search_layout.hbs
+++ b/app/modules/inventory/views/add/templates/search_layout.hbs
@@ -1,9 +1,9 @@
 <section class="inner">
   <h3>{{i18n 'search by'}}</h3>
   <div class="search-buttons">
-    <a href="/search?type=book" class="search-button">
+    <a href="/search?type=work" class="search-button">
       {{icon 'search'}}
-      {{I18n 'book'}}
+      {{I18n 'work'}}
     </a>
     <a href="/search?type=author" class="search-button">
       {{icon 'search'}}

--- a/app/modules/search/lib/formatters.js
+++ b/app/modules/search/lib/formatters.js
@@ -1,0 +1,24 @@
+import error_ from 'lib/error'
+
+// Pre-formatting is required to set the type
+// Taking the opportunity to omit all non-required data
+export const formatSubject = result => ({
+  id: result.id,
+  label: result.label,
+  description: result.description,
+  uri: `wd:${result.id}`,
+  type: 'subjects'
+})
+
+export const formatEntity = function (entity) {
+  if (entity?.toJSON == null) {
+    error_.report('cant format invalid entity', { entity })
+    return
+  }
+
+  const data = entity.toJSON()
+  data.image = data.image?.url
+  // Return a model to prevent having it re-formatted
+  // as a Result model, which works from a result object, not an entity
+  return new Backbone.Model(data)
+}

--- a/app/modules/search/lib/search_sections.js
+++ b/app/modules/search/lib/search_sections.js
@@ -1,3 +1,5 @@
+import { I18n } from 'modules/user/lib/i18n'
+
 export const sectionToTypes = {
   entity: {
     all: [ 'works', 'humans', 'series', 'publishers', 'collections' ],
@@ -42,6 +44,9 @@ export const sectionsData = selected => {
   if (sections.entity.all.selected) setIncludeFlag(sections.entity)
   else if (sections.social.all.selected) setIncludeFlag(sections.social)
 
+  sections.entity.all.includes = getIncludedSectionsLabel(sections.entity)
+  sections.social.all.includes = getIncludedSectionsLabel(sections.social)
+
   return sections
 }
 
@@ -54,3 +59,7 @@ const setIncludeFlag = categorySections => {
 }
 
 export const neverIncluded = [ 'all', 'subject' ]
+
+const isIncluded = name => !neverIncluded.includes(name)
+
+const getIncludedSectionsLabel = section => Object.keys(section).filter(isIncluded)

--- a/app/modules/search/lib/search_sections.js
+++ b/app/modules/search/lib/search_sections.js
@@ -1,0 +1,56 @@
+export const sectionToTypes = {
+  entity: {
+    all: [ 'works', 'humans', 'series', 'publishers', 'collections' ],
+    book: 'works',
+    author: 'humans',
+    serie: 'series',
+    collection: 'collections',
+    publisher: 'publishers',
+    subject: 'subjects',
+  },
+  social: {
+    all: [ 'users', 'groups' ],
+    user: 'users',
+    group: 'groups'
+  }
+}
+
+export const entitySectionsWithAlternatives = [ 'all', 'book', 'author', 'serie', 'collection', 'publisher' ]
+
+export const sectionsData = selected => {
+  const sections = {
+    entity: {
+      all: { label: 'all' },
+      book: { label: 'book' },
+      author: { label: 'author' },
+      serie: { label: 'series_singular' },
+      publisher: { label: 'publisher' },
+      collection: { label: 'collection' },
+      subject: { label: 'subject' }
+    },
+    social: {
+      all: { label: 'all' },
+      user: { label: 'user' },
+      group: { label: 'group' },
+    },
+  }
+
+  if (sections.entity[selected]) sections.entity[selected].selected = true
+  else if (sections.social[selected]) sections.social[selected].selected = true
+  else sections.entity.all.selected = true
+
+  if (sections.entity.all.selected) setIncludeFlag(sections.entity)
+  else if (sections.social.all.selected) setIncludeFlag(sections.social)
+
+  return sections
+}
+
+const setIncludeFlag = categorySections => {
+  for (const name in categorySections) {
+    if (!neverIncluded.includes(name)) {
+      categorySections[name].included = true
+    }
+  }
+}
+
+export const neverIncluded = [ 'all', 'subject' ]

--- a/app/modules/search/lib/search_sections.js
+++ b/app/modules/search/lib/search_sections.js
@@ -1,7 +1,7 @@
 export const sectionToTypes = {
   entity: {
     all: [ 'works', 'humans', 'series', 'publishers', 'collections' ],
-    book: 'works',
+    work: 'works',
     author: 'humans',
     serie: 'series',
     collection: 'collections',
@@ -15,13 +15,13 @@ export const sectionToTypes = {
   }
 }
 
-export const entitySectionsWithAlternatives = [ 'all', 'book', 'author', 'serie', 'collection', 'publisher' ]
+export const entitySectionsWithAlternatives = [ 'all', 'work', 'author', 'serie', 'collection', 'publisher' ]
 
 export const sectionsData = selected => {
   const sections = {
     entity: {
       all: { label: 'all' },
-      book: { label: 'book' },
+      work: { label: 'work' },
       author: { label: 'author' },
       serie: { label: 'series_singular' },
       publisher: { label: 'publisher' },

--- a/app/modules/search/models/result.js
+++ b/app/modules/search/models/result.js
@@ -15,7 +15,7 @@ const entityFormatter = (type, typeAlias) => function (data) {
 }
 
 const typeFormatters = {
-  works: entityFormatter('work', 'book'),
+  works: entityFormatter('work'),
   humans: entityFormatter('author'),
   series: entityFormatter('serie'),
   collections: entityFormatter('collection'),

--- a/app/modules/search/scss/_live_search.scss
+++ b/app/modules/search/scss/_live_search.scss
@@ -9,8 +9,7 @@
     overflow-x: auto;
   }
   .searchSection{
-    width: $search-section-width;
-    padding: 0.5em 0.2em;
+    min-width: $search-section-width-on-large-screen;
     background-color: #f3f3f3;
     @include transition(background-color);
     &.included{
@@ -160,7 +159,7 @@
   }
   /*Smaller screens*/
   @media screen and (max-width: $smaller-screen) {
-    height: 100%;
+    max-height: 90vh;
     @include display-flex(column);
     .propositions{
       justify-content: center;
@@ -168,13 +167,41 @@
     .sections{
       flex: 0 0 auto;
       border-top: 1px solid #ccc;
+      border-bottom: 1px solid #ccc;
+      @include display-flex(row, stretch, center);
+      > div{
+        width: 50%;
+        @include display-flex(row, stretch, center);
+      }
+    }
+    .searchSection{
+      flex: 1 0 0;
+      @include display-flex(column, stretch, center);
+      &:not([data-name="all"]){
+        display: none;
+      }
+      padding: 0 0.2em;
+      min-height: 2.5em;
+    }
+    .unwrapped{
+      display: none;
+    }
+    .wrapped{
+      @include display-flex(row, space-between, center, wrap);
+      span{
+        padding: 0 0.2em;
+      }
     }
   }
 
-  /*Medium to Large screens*/
+  /*Large screens*/
   @media screen and (min-width: $smaller-screen) {
-    .resultsWrapper{
-      max-height: 60vh;
+    .searchSection{
+      width: $search-section-width-on-large-screen;
+      padding: 0.5em 0.2em;
+    }
+    .wrapped{
+      display: none;
     }
   }
 }

--- a/app/modules/search/scss/_live_search.scss
+++ b/app/modules/search/scss/_live_search.scss
@@ -3,17 +3,19 @@
   .resultsWrapper, .sections{
     background-color: #eee;
   }
-  .sections{
+  .entitySections, .socialSections{
     @include display-flex(row, flex-end, flex-start, wrap);
     text-align: center;
     overflow-x: auto;
   }
   .searchSection{
-    flex: 1 0 6em;
-    max-width: 8em;
+    width: $search-section-width;
     padding: 0.5em 0.2em;
     background-color: #f3f3f3;
     @include transition(background-color);
+    &.included{
+      background-color: #ddd;
+    }
     &:hover, &.selected{
       background-color: $light-blue;
       color: white;

--- a/app/modules/search/search.js
+++ b/app/modules/search/search.js
@@ -89,14 +89,14 @@ const findSearchSection = function (q) {
 
 const sections = {
   a: 'author',
-  b: 'book',
+  b: 'work', // 'b' for book
   c: 'collection',
   g: 'group',
   h: 'author', // 'h' for human
-  l: 'book', // 'l' for livre, libro, liber
+  l: 'work', // 'l' for livre, libro, liber
   p: 'publisher',
   s: 'serie',
   t: 'subject', // 't' for topic (as series already use the 's')
   u: 'user',
-  w: 'book' // 'w' for work
+  w: 'work',
 }

--- a/app/modules/search/views/templates/live_search.hbs
+++ b/app/modules/search/views/templates/live_search.hbs
@@ -1,8 +1,3 @@
-<div class="resultsWrapper">
-  <ul class="results"></ul>
-  <div class="loaderWrapper"></div>
-</div>
-
 <div class="sections">
   <div class="entitySections">
     {{#each sections.entity}}
@@ -28,6 +23,11 @@
       </a>
     {{/each}}
   </div>
+</div>
+
+<div class="resultsWrapper">
+  <ul class="results"></ul>
+  <div class="loaderWrapper"></div>
 </div>
 
 <div class="alternatives">

--- a/app/modules/search/views/templates/live_search.hbs
+++ b/app/modules/search/views/templates/live_search.hbs
@@ -4,11 +4,20 @@
 </div>
 
 <div class="sections">
-  {{#each sections}}
-    <a id="section-{{@key}}" class="searchSection {{#if selected}}selected{{/if}}">
-      {{I18n label}}
-    </a>
-  {{/each}}
+  <div class="entitySections">
+    {{#each sections.entity}}
+      <a data-category="entity" data-name="{{@key}}" class="searchSection {{#if selected}}selected{{/if}} {{#if included}}included{{/if}}">
+        {{I18n label}}
+      </a>
+    {{/each}}
+  </div>
+  <div class="socialSections">
+    {{#each sections.social}}
+      <a data-category="social" data-name="{{@key}}" class="searchSection {{#if selected}}selected{{/if}} {{#if included}}included{{/if}}">
+        {{I18n label}}
+      </a>
+    {{/each}}
+  </div>
 </div>
 
 <div class="alternatives">

--- a/app/modules/search/views/templates/live_search.hbs
+++ b/app/modules/search/views/templates/live_search.hbs
@@ -7,14 +7,24 @@
   <div class="entitySections">
     {{#each sections.entity}}
       <a data-category="entity" data-name="{{@key}}" class="searchSection {{#if selected}}selected{{/if}} {{#if included}}included{{/if}}">
-        {{I18n label}}
+        {{#if includes}}
+          <span class="unwrapped">{{I18n label}}</span>
+          <span class="wrapped">{{#each includes}}<span>{{I18n this}}</span>{{/each}}</span>
+        {{else}}
+          {{I18n label}}
+        {{/if}}
       </a>
     {{/each}}
   </div>
   <div class="socialSections">
     {{#each sections.social}}
       <a data-category="social" data-name="{{@key}}" class="searchSection {{#if selected}}selected{{/if}} {{#if included}}included{{/if}}">
-        {{I18n label}}
+        {{#if includes}}
+          <span class="unwrapped">{{I18n label}}</span>
+          <span class="wrapped">{{#each includes}}<span>{{I18n this}}</span>{{/each}}</span>
+        {{else}}
+          {{I18n label}}
+        {{/if}}
       </a>
     {{/each}}
   </div>


### PR DESCRIPTION
New attempt to makes a clear separation between searching for entities and searching for groups or users.
To be merged after merging server branch `elasticsearch-upgrade`

Here is a glimpse
![multi_search_bar](https://user-images.githubusercontent.com/1596934/101889807-2070c680-3ba0-11eb-957d-c5048b947794.gif)

Pros
* Gives a visual idea of what sections are selected from selecting all
* Preserve keyboard navigation

Cons
* There are now 2 "All", which can be a bit weird. An alternative could be to replace "All" by "Entities" and "Social", but then we are back at throwing the term "Entities" at the face of new users (which nevertheless would have the good side of introducing the concept)