### PR TITLE
inventory_network_nav: display friend requests and group invitations as sub sections

### DIFF
--- a/app/modules/inventory/scss/_inventory_nav_lists.scss
+++ b/app/modules/inventory/scss/_inventory_nav_lists.scss
@@ -1,6 +1,6 @@
 $nav-avatar-size: 5em;
 
-#usersList, #groupsList, #membersList{
+#usersList, #groupsList, #friendRequestsList, #groupsInvitationsList, #membersList{
   ul{
     @include display-flex(row, center, flex-start, wrap);
     margin: 0 auto;
@@ -48,7 +48,7 @@ $nav-avatar-size: 5em;
   }
 }
 
-#usersList, #groupsList{
+#usersList, #groupsList, #groupsInvitationsList{
   ul{
     @include radius;
     background-color: #f0f0f0;
@@ -97,5 +97,14 @@ $nav-avatar-size: 5em;
     background-color: $light-blue;
     background-color: $light-blue;
     color: $light-grey;
+  }
+}
+
+.friendRequestsWrapper, .groupsInvitationsWrapper{
+  padding: 0.5em;
+  margin-top: 0.5em;
+  @include radius;
+  &, ul{
+    background-color: darken(#eeeeee, 5%);
   }
 }

--- a/app/modules/inventory/views/inventory_common_nav.js
+++ b/app/modules/inventory/views/inventory_common_nav.js
@@ -1,10 +1,7 @@
 import SectionList from './inventory_section_list'
 
 export default Marionette.LayoutView.extend({
-  regions: {
-    usersList: '#usersList',
-    groupsList: '#groupsList'
-  },
-
-  showList (region, collection) { return region.show(new SectionList({ collection })) }
+  showList (region, collection) {
+    if (this.isIntact()) region.show(new SectionList({ collection }))
+  }
 })

--- a/app/modules/inventory/views/inventory_network_nav.js
+++ b/app/modules/inventory/views/inventory_network_nav.js
@@ -10,19 +10,40 @@ export default InventoryCommonNav.extend({
     PreventDefault: {}
   },
 
+  regions: {
+    usersList: '#usersList',
+    groupsList: '#groupsList',
+    friendRequestsList: '#friendRequestsList',
+    groupsInvitationsList: '#groupsInvitationsList',
+  },
+
   ui: {
     showUsersMenu: '.showUsersMenu',
     showGroupsMenu: '.showGroupsMenu',
     userMenu: '.userMenu',
-    groupMenu: '.groupMenu'
+    groupMenu: '.groupMenu',
+    friendRequestsWrapper: '.friendRequestsWrapper',
+    groupsInvitationsWrapper: '.groupsInvitationsWrapper',
   },
 
-  onShow () {
-    app.request('fetch:friends')
-    .then(() => this.showList(this.usersList, app.users.filtered.friends()))
+  async onShow () {
+    await Promise.all([
+      app.request('fetch:friends'),
+      app.request('fetch:otherRequested'),
+      app.request('wait:for', 'groups'),
+    ])
 
-    return app.request('wait:for', 'groups')
-    .then(() => this.showList(this.groupsList, app.groups))
+    this.showList(this.usersList, app.users.friends)
+    if (app.users.otherRequested.length > 0) {
+      this.showList(this.friendRequestsList, app.users.otherRequested)
+      this.ui.friendRequestsWrapper.removeClass('hidden')
+    }
+
+    this.showList(this.groupsList, app.groups.mainUserMember)
+    if (app.groups.mainUserInvited.length > 0) {
+      this.showList(this.groupsInvitationsList, app.groups.mainUserInvited)
+      this.ui.groupsInvitationsWrapper.removeClass('hidden')
+    }
   },
 
   events: {

--- a/app/modules/inventory/views/inventory_public_nav.js
+++ b/app/modules/inventory/views/inventory_public_nav.js
@@ -34,6 +34,11 @@ export default InventoryCommonNav.extend({
     this.listenTo(app.user, 'confirmed:position', this.lazyRender.bind(this))
   },
 
+  regions: {
+    usersList: '#usersList',
+    groupsList: '#groupsList',
+  },
+
   behaviors: {
     Loading: {}
   },

--- a/app/modules/inventory/views/templates/inventory_network_nav.hbs
+++ b/app/modules/inventory/views/templates/inventory_network_nav.hbs
@@ -10,6 +10,11 @@
       </div>
     </div>
     <div id="usersList"></div>
+
+    <div class="friendRequestsWrapper hidden">
+      <p class="list-label">{{I18n 'friend requests'}}</p>
+      <div id="friendRequestsList"></div>
+    </div>
   </div>
 
   <div class="list-wrapper">
@@ -23,5 +28,10 @@
       </div>
     </div>
     <div id="groupsList"></div>
+
+    <div class="groupsInvitationsWrapper hidden">
+      <p class="list-label">{{I18n 'invitations'}}</p>
+      <div id="groupsInvitationsList"></div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The primary motivation was to get invitations out of the groups list: now when declining an invitation, the list is updated, because it is bound to a more specific collection than just `app.groups`, which includes all groups you were you are member or invited when the session starts, and doesn't remove groups models from the collection when an invitation to join is declined. So I started looking at how to use a collection that would be updated, but once I got there, it seemed that there was an opportunity to make better users and groups lists, thus this proposition

## before
![before](https://user-images.githubusercontent.com/1596934/103287481-e8acb000-49e2-11eb-9530-e3d591b25a21.jpg)

## after
![after](https://user-images.githubusercontent.com/1596934/103287488-ec403700-49e2-11eb-8895-cb297c8c3ab3.jpg)

## Ideas
* maybe those friend requests and invitations lists can get annoying, so it could make sense to have them wrapped up by default, with a counter, and wait for a click to unwrap