### PR TITLE
Go to next task when invalid

### DIFF
--- a/app/modules/tasks/models/task.js
+++ b/app/modules/tasks/models/task.js
@@ -28,7 +28,9 @@ export default Backbone.Model.extend({
       const resolvedUri = model.get('uri')
       if (resolvedUri !== uri) {
         const context = { task: this.id, oldUri: uri, newUri: resolvedUri }
-        throw error_.new(`${name} uri is obsolete`, 500, context)
+        const err = error_.new(`${name} uri is obsolete`, 500, context)
+        err.code = 'obsolete_task'
+        throw err
       }
 
       return model.initAuthorWorks()

--- a/app/modules/tasks/models/task.js
+++ b/app/modules/tasks/models/task.js
@@ -21,7 +21,7 @@ export default Backbone.Model.extend({
     })
   },
 
-  grabAuthor (name, isShownFromId) {
+  grabAuthor (name) {
     const uri = this.get(`${name}Uri`)
     return this.reqGrab('get:entity:model', uri, name)
     .then(model => {
@@ -35,7 +35,7 @@ export default Backbone.Model.extend({
     })
   },
 
-  grabSuspect (isShownFromId) { return this.grabAuthor('suspect', isShownFromId) },
+  grabSuspect () { return this.grabAuthor('suspect') },
 
   grabSuggestion () { return this.grabAuthor('suggestion') },
 

--- a/app/modules/tasks/models/task.js
+++ b/app/modules/tasks/models/task.js
@@ -21,21 +21,24 @@ export default Backbone.Model.extend({
     })
   },
 
-  grabAuthor (name) {
+  grabAuthor (name, isShownFromId) {
     const uri = this.get(`${name}Uri`)
     return this.reqGrab('get:entity:model', uri, name)
     .then(model => {
       const resolvedUri = model.get('uri')
       if (resolvedUri !== uri) {
-        const context = { task: this.id, oldUri: uri, newUri: resolvedUri }
-        throw error_.new(`${name} uri is obsolete`, 500, context)
+        if (isShownFromId) {
+          const context = { task: this.id, oldUri: uri, newUri: resolvedUri }
+          throw error_.new(`${name} uri is obsolete`, 500, context)
+        }
+        return this.showNextTask()
       }
 
       return model.initAuthorWorks()
     })
   },
 
-  grabSuspect () { return this.grabAuthor('suspect') },
+  grabSuspect (isShownFromId) { return this.grabAuthor('suspect', isShownFromId) },
 
   grabSuggestion () { return this.grabAuthor('suggestion') },
 

--- a/app/modules/tasks/models/task.js
+++ b/app/modules/tasks/models/task.js
@@ -27,11 +27,8 @@ export default Backbone.Model.extend({
     .then(model => {
       const resolvedUri = model.get('uri')
       if (resolvedUri !== uri) {
-        if (isShownFromId) {
-          const context = { task: this.id, oldUri: uri, newUri: resolvedUri }
-          throw error_.new(`${name} uri is obsolete`, 500, context)
-        }
-        return this.showNextTask()
+        const context = { task: this.id, oldUri: uri, newUri: resolvedUri }
+        throw error_.new(`${name} uri is obsolete`, 500, context)
       }
 
       return model.initAuthorWorks()

--- a/app/modules/tasks/views/tasks_layout.js
+++ b/app/modules/tasks/views/tasks_layout.js
@@ -40,7 +40,7 @@ export default Marionette.LayoutView.extend({
   onShow () {
     const { task } = this.options
     if (isModel(task)) {
-      this.showTask({ taskModelPromise: Promise.resolve(task) })
+      this.showTask({ task })
     } else if (task != null) {
       this.showFromId(task)
     } else {
@@ -48,7 +48,7 @@ export default Marionette.LayoutView.extend({
     }
   },
 
-  showNextTask (params = {}) {
+  async showNextTask (params = {}) {
     const { spinner } = params
     if (spinner != null) startLoading.call(this, spinner)
     let offset = app.request('querystring:get', 'offset')
@@ -60,17 +60,16 @@ export default Marionette.LayoutView.extend({
       }
     })
     if (spinner != null) stopLoading.call(this, spinner)
-    this.showTask({ taskModelPromise: nextTask })
+    this.showTask({ task: nextTask })
   },
 
-  showTask (params) {
-    const { taskModelPromise, isShownFromId } = params
-    return taskModelPromise
-    .then(model => this.showFromModel(model, isShownFromId))
+  async showTask ({ task, isShownFromId }) {
+    task = await task
+    this.showFromModel(task, isShownFromId)
     .catch(app.Execute('show:error'))
   },
 
-  showFromModel (model, isShownFromId) {
+  async showFromModel (model, isShownFromId) {
     this.previousTask = this.currentTaskModel
     this.currentTaskModel = model
 
@@ -118,8 +117,8 @@ export default Marionette.LayoutView.extend({
     })
   },
 
-  showFromId (id) {
-    this.showTask({ taskModelPromise: getTaskById(id), isShownFromId: true })
+  async showFromId (id) {
+    this.showTask({ task: await getTaskById(id), isShownFromId: true })
   },
 
   focusOnControls () {

--- a/app/modules/tasks/views/tasks_layout.js
+++ b/app/modules/tasks/views/tasks_layout.js
@@ -51,8 +51,14 @@ export default Marionette.LayoutView.extend({
   showNextTask (params = {}) {
     const { spinner } = params
     if (spinner != null) startLoading.call(this, spinner)
-    const offset = app.request('querystring:get', 'offset')
+    let offset = app.request('querystring:get', 'offset')
     const nextTask = getNextTask({ previousTasks, offset, lastTaskModel: this.currentTaskModel })
+    .catch(err => {
+      offset += 1
+      if (err.message.match('invalid task')) {
+        return getNextTask({ previousTasks, offset, lastTaskModel: this.currentTaskModel })
+      }
+    })
     if (spinner != null) stopLoading.call(this, spinner)
     this.showTask({ taskModelPromise: nextTask })
   },

--- a/app/modules/tasks/views/tasks_layout.js
+++ b/app/modules/tasks/views/tasks_layout.js
@@ -115,8 +115,8 @@ export default Marionette.LayoutView.extend({
   },
 
   handleShowError (err) {
-    if (err.code === 'obsolete_task') {
-      console.warn('passing obsolete task', err.context)
+    if (err.code === 'obsolete_task' || err.message === 'entity_not_found') {
+      console.warn('passing task error', err.message, err.context)
       this.showNextTask({ spinner: '.next' })
     } else {
       app.execute('show:error', err)

--- a/app/modules/tasks/views/tasks_layout.js
+++ b/app/modules/tasks/views/tasks_layout.js
@@ -79,7 +79,7 @@ export default Marionette.LayoutView.extend({
 
     previousTasks.push(model.get('_id'))
 
-    this._grabSuspectPromise = model.grabSuspect()
+    this._grabSuspectPromise = model.grabSuspect(isShownFromId)
 
     return Promise.all([
       this.showCurrentTask(model),

--- a/app/modules/tasks/views/tasks_layout.js
+++ b/app/modules/tasks/views/tasks_layout.js
@@ -66,11 +66,11 @@ export default Marionette.LayoutView.extend({
   showTask (params) {
     const { taskModelPromise, isShownFromId } = params
     return taskModelPromise
-    .then(this.showFromModel.bind(this, isShownFromId))
+    .then(model => this.showFromModel(model, isShownFromId))
     .catch(app.Execute('show:error'))
   },
 
-  showFromModel (isShownFromId, model) {
+  showFromModel (model, isShownFromId) {
     this.previousTask = this.currentTaskModel
     this.currentTaskModel = model
 
@@ -85,7 +85,7 @@ export default Marionette.LayoutView.extend({
 
     previousTasks.push(model.get('_id'))
 
-    this._grabSuspectPromise = model.grabSuspect(isShownFromId)
+    this._grabSuspectPromise = model.grabSuspect()
 
     return Promise.all([
       this.showCurrentTask(model),


### PR DESCRIPTION
The idea is to have fluid experience when going from task to task.
Some task may be invalid, some may have already redirected suspect uri, in this case it simply go to the next one (but not when client come from a url with a task id)
Initially a commit which archive the task (by creating a state) was intended, but it doesnt seem necessary as it may disturb some tasks state. This client responsibility is only to ensure a smooth experience, not update tasks whatsoever.