### PR TITLE
display prerendered content to users with JS disabled

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,6 +12,9 @@
   <meta http-equiv="expires" content="0">
   <meta http-equiv="pragma" content="no-cache">
 
+  <!-- Instruct Nginx to send the prerendered version. In case there is no Nginx to catch that request, the page will be reloaded in loop, thus the 1 second delay, to give a chance to close the page before saturating a small CPU -->
+  <noscript><meta http-equiv="refresh" content="1;?__nojs" /></noscript>
+
   <link rel="canonical" href="https://inventaire.io/" />
   <link rel="sitemap" href="/public/sitemaps/sitemapindex.xml" />
   <link rel="alternate" type="application/rss+xml" href="https://wiki.inventaire.io/blog.rss">
@@ -60,7 +63,9 @@
   <div class="full-screen-loader"><div></div></div>
 </div>
 
-<noscript>sorry, this website can't work without javascript activated</noscript>
+<noscript>
+  <p id="nojs-warning">This webapp heavily uses JavaScript. You can read its source code from <a href="https://github.com/inventaire/inventaire-client">our client code repository</a></p>
+</noscript>
 
 </body>
 </html>

--- a/app/modules/general/scss/_general_settings.scss
+++ b/app/modules/general/scss/_general_settings.scss
@@ -104,6 +104,15 @@ body{
   display: inherit;
 }
 
-noscript{
-  padding: 1em;
+#nojs-warning{
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 100;
+  background-color: $yellow;
+  padding: 0 0.5em;
+  a{
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
In prod, the added `__nojs` flag [makes nginx send the prerendered version](https://github.com/inventaire/inventaire-deploy/commit/188581d)

That prerendered version is returned without the `meta http-equiv="refresh"` tag to prevent a redirection loop.

In development, in absence of Nginx to catch that flag, disabling JS triggers that redirection loop, thus the 1 second delay in the redirection to be nice to developers