### PR TITLE
add identifiers to authors

### DIFF
--- a/app/lib/handlebars_helpers/claims.js
+++ b/app/lib/handlebars_helpers/claims.js
@@ -6,7 +6,7 @@ import wdLang from 'wikidata-lang'
 import commons_ from 'lib/wikimedia/commons'
 import linkify_ from './linkify'
 import platforms_ from './platforms'
-import identifiers_ from './identifiers'
+import identifiersUrls_ from './identifiers'
 import {
   prop as propHelper,
   entity as entityHelper,
@@ -99,11 +99,9 @@ export default API = {
     const [ claims, prop ] = neutralizeDataObject(args)
     const firstId = claims?.[prop]?.[0]
     if (firstId != null) {
-      const identifier = identifiers_[prop]
       const label = labelString(prop)
-      const url = identifier.url(firstId)
-      const textId = identifier.text(firstId)
-      const values = linkify_(textId, url, 'link')
+      const url = identifiersUrls_[prop](firstId)
+      const values = linkify_(firstId, url, 'link')
       return claimString(label, values)
     }
   },

--- a/app/lib/handlebars_helpers/claims.js
+++ b/app/lib/handlebars_helpers/claims.js
@@ -1,6 +1,7 @@
 import { isEntityUri, isImageHash } from 'lib/boolean_tests'
 import typeOf from 'lib/type_of'
 import { i18n } from 'modules/user/lib/i18n'
+import { localStorageProxy } from 'lib/local_storage'
 import * as icons_ from './icons'
 import wdLang from 'wikidata-lang'
 import commons_ from 'lib/wikimedia/commons'
@@ -97,6 +98,7 @@ export default API = {
 
   identifierClaim (...args) {
     const [ claims, prop ] = neutralizeDataObject(args)
+    if (!isUserPreference(prop)) return ''
     const firstId = claims?.[prop]?.[0]
     if (firstId != null) {
       const label = labelString(prop)
@@ -156,4 +158,8 @@ const imagePreview = imageHash => {
       <p class="image-hash">${imageHash}</p>
     </a>
   `
+}
+const isUserPreference = prop => {
+  const props = localStorageProxy.getItem('customIdentifiers')
+  return prop in props
 }

--- a/app/lib/handlebars_helpers/claims.js
+++ b/app/lib/handlebars_helpers/claims.js
@@ -6,6 +6,7 @@ import wdLang from 'wikidata-lang'
 import commons_ from 'lib/wikimedia/commons'
 import linkify_ from './linkify'
 import platforms_ from './platforms'
+import identifiers_ from './identifiers'
 import {
   prop as propHelper,
   entity as entityHelper,
@@ -91,6 +92,19 @@ export default API = {
       const url = platform.url(firstPlatformId)
       const values = linkify_(text, url, 'link social-network')
       return claimString('', values)
+    }
+  },
+
+  identifierClaim (...args) {
+    const [ claims, prop ] = neutralizeDataObject(args)
+    const firstId = claims?.[prop]?.[0]
+    if (firstId != null) {
+      const identifier = identifiers_[prop]
+      const label = labelString(prop)
+      const url = identifier.url(firstId)
+      const textId = identifier.text(firstId)
+      const values = linkify_(textId, url, 'link')
+      return claimString(label, values)
     }
   },
 

--- a/app/lib/handlebars_helpers/identifiers.js
+++ b/app/lib/handlebars_helpers/identifiers.js
@@ -1,6 +1,14 @@
 export default {
-  'wdt:P496': {
-    text: _.identity,
-    url (id) { return `https://orcid.org/${id}` }
-  },
+  'wdt:P213': id => `https://isni.oclc.org/xslt/DB=1.2//CMD?ACT=SRCH&IKT=8006&TRM=ISN%3A${id}`,
+  'wdt:P214': id => `https://viaf.org/viaf/${id}`,
+  'wdt:P227': id => `https://d-nb.info/gnd/${id}`,
+  'wdt:P244': id => `https://id.loc.gov/authorities/${id}`,
+  'wdt:P268': id => `https://catalogue.bnf.fr/ark:/12148/cb${id}`,
+  'wdt:P269': id => `https://www.idref.fr/${id}`,
+  'wdt:P271': id => `https://ci.nii.ac.jp/author/${id}`,
+  'wdt:P496': id => `https://orcid.org/${id}`,
+  'wdt:P950': id => `http://datos.bne.es/persona/${id}.html`,
+  'wdt:P1006': id => `https://data.bibliotheken.nl/id/thes/p${id}`,
+  'wdt:P1015': id => `https://authority.bibsys.no/authority/rest/authorities/html/${id}`,
+  'wdt:P7859': id => `https://www.worldcat.org/identities/${id}`
 }

--- a/app/lib/handlebars_helpers/identifiers.js
+++ b/app/lib/handlebars_helpers/identifiers.js
@@ -1,0 +1,6 @@
+export default {
+  'wdt:P496': {
+    text: _.identity,
+    url (id) { return `https://orcid.org/${id}` }
+  },
+}

--- a/app/modules/entities/lib/editor/properties_per_type.js
+++ b/app/modules/entities/lib/editor/properties_per_type.js
@@ -52,6 +52,7 @@ export default {
   human: {
     'wdt:P1412': {}, // languages of expression
     'wdt:P135': {}, // movement
+    'wdt:P496': {}, // ORCID
     'wdt:P569': {}, // date of birth
     'wdt:P570': {}, // date of death
     'wdt:P737': {}, // influenced by

--- a/app/modules/entities/lib/editor/properties_per_type.js
+++ b/app/modules/entities/lib/editor/properties_per_type.js
@@ -50,19 +50,30 @@ export default {
   },
 
   human: {
-    'wdt:P1412': {}, // languages of expression
     'wdt:P135': {}, // movement
+    'wdt:P213': {}, // ISNI
+    'wdt:P214': {}, // VIAF ID
+    'wdt:P227': {}, // GND ID
+    'wdt:P244': {}, // Library of Congress authority ID
+    'wdt:P268': {}, // BNF ID
+    'wdt:P269': {}, // IdRef ID
+    'wdt:P271': {}, // CiNii author ID (books)
     'wdt:P496': {}, // ORCID
     'wdt:P569': {}, // date of birth
     'wdt:P570': {}, // date of death
     'wdt:P737': {}, // influenced by
     'wdt:P856': {}, // official website
+    'wdt:P950': {}, // Biblioteca Nacional de España ID
+    'wdt:P1006': {}, // Nationale Thesaurus voor Auteurs ID
+    'wdt:P1015': {}, // BIBSYS ID
+    'wdt:P1412': {}, // languages of expression
     'wdt:P2002': {}, // Twitter account
-    'wdt:P2013': {}, // Facebook account
     'wdt:P2003': {}, // Instagram username
+    'wdt:P2013': {}, // Facebook account
     'wdt:P2397': {}, // YouTube channel ID
-    'wdt:P4033': {}
-  }, // Mastodon address
+    'wdt:P4033': {}, // Mastodon address
+    'wdt:P7859': {}, // WorldCat Identities ID
+  },
 
   // Using omit instead of having a common list, extended for works, so that
   // the properties order isn't constrained by being part or not of the common properties

--- a/app/modules/entities/lib/properties.js
+++ b/app/modules/entities/lib/properties.js
@@ -71,6 +71,8 @@ addProp('wdt:P1476', 'string', null, false, null)
 addProp('wdt:P1680', 'string', null, false, null)
 
 // # human
+// ORCID
+addProp('wdt:P496', 'string', null, false, null)
 // date of birth
 addProp('wdt:P569', 'simple-day', null, false, null)
 // date of death

--- a/app/modules/entities/views/templates/author_claims.hbs
+++ b/app/modules/entities/views/templates/author_claims.hbs
@@ -14,6 +14,7 @@
     {{claim claims 'wdt:P1066' true}} {{!-- student of --}}
     {{claim claims 'wdt:P737' true}} {{!-- influence by --}}
     {{urlClaim claims 'wdt:P856'}} {{!-- official website --}}
+    {{identifierClaim claims 'wdt:P496'}} {{!-- ORCID --}}
     {{platformClaim claims 'wdt:P4033'}} {{!-- mastodon --}}
     {{platformClaim claims 'wdt:P2002'}} {{!-- twitter --}}
     {{platformClaim claims 'wdt:P2013'}} {{!-- facebook --}}

--- a/app/modules/entities/views/templates/author_claims.hbs
+++ b/app/modules/entities/views/templates/author_claims.hbs
@@ -14,12 +14,23 @@
     {{claim claims 'wdt:P1066' true}} {{!-- student of --}}
     {{claim claims 'wdt:P737' true}} {{!-- influence by --}}
     {{urlClaim claims 'wdt:P856'}} {{!-- official website --}}
-    {{identifierClaim claims 'wdt:P496'}} {{!-- ORCID --}}
     {{platformClaim claims 'wdt:P4033'}} {{!-- mastodon --}}
     {{platformClaim claims 'wdt:P2002'}} {{!-- twitter --}}
     {{platformClaim claims 'wdt:P2013'}} {{!-- facebook --}}
     {{platformClaim claims 'wdt:P2003'}} {{!-- instagram --}}
     {{platformClaim claims 'wdt:P2397'}} {{!-- youtube --}}
+    {{identifierClaim claims 'wdt:P213'}} {{!-- ISNI --}}
+    {{identifierClaim claims 'wdt:P214'}} {{!-- VIAF ID --}}
+    {{identifierClaim claims 'wdt:P227'}} {{!-- GND ID --}}
+    {{identifierClaim claims 'wdt:P244'}} {{!-- Library of Congress authority ID --}}
+    {{identifierClaim claims 'wdt:P268' }} {{!-- BNF ID --}}
+    {{identifierClaim claims 'wdt:P269'}} {{!-- IdRef ID --}}
+    {{identifierClaim claims 'wdt:P271'}} {{!-- CiNii author ID (books) --}}
+    {{identifierClaim claims 'wdt:P496'}} {{!-- ORCID --}}
+    {{identifierClaim claims 'wdt:P950'}} {{!-- Biblioteca Nacional de España ID --}}
+    {{identifierClaim claims 'wdt:P1006'}} {{!-- Nationale Thesaurus voor Auteurs ID --}}
+    {{identifierClaim claims 'wdt:P1015'}} {{!-- BIBSYS ID --}}
+    {{identifierClaim claims 'wdt:P7859'}} {{!-- WorldCat Identities ID --}}
     {{#if hasEbooks}}{{> 'entities:ebooks' this}}{{/if}}
   </p>
 </div>


### PR DESCRIPTION
the current state of this pr is intended to be a base of discussion to start integrating some identifier to authors layout
with the idea to improve tasks suggestions (as described in #501)
maybe we could wrap the identifiers to only display it on a user's click, maybe we could only display it in a taks context, maybe its fine like this now, i dont have a strong opinion on any of those suggestions