### PR TITLE
remove the listing dropdown option "remove item"

### DIFF
--- a/app/modules/inventory/views/item_card.js
+++ b/app/modules/inventory/views/item_card.js
@@ -36,7 +36,6 @@ export default ItemItemView.extend({
   events: {
     'click a.transaction': 'updateTransaction',
     'click a.listing': 'updateListing',
-    'click a.remove': 'itemDestroy',
     'click a.itemShow': 'itemShow',
     'click a.user': 'showUser',
     'click a.showUser': 'showUser',

--- a/app/modules/inventory/views/templates/item_visibility_box.hbs
+++ b/app/modules/inventory/views/templates/item_visibility_box.hbs
@@ -16,10 +16,6 @@
           </a>
         </li>
       {{/each}}
-      <li><label>{{i18n 'other operations:'}}</label></li>
-      <li>
-        <a class="remove dark-grey">{{icon 'trash-o'}} {{I18n 'delete'}}</a>
-      </li>
     </ul>
   </div>
 {{/unless}}


### PR DESCRIPTION
for 2 reasons:
  - a remove item action button is already available on the item modal
  - this dropdown is about listing/visibility which has little (not to
  say nothing) to do with the rest of the options

only the template is affected since the layout is still triggered by the
remove class of the html element in the modal

related PR: #271 

message to reviewer: feel free to close it if you disagree