### PR TITLE
Broken wiki link in credits

### DIFF
--- a/app/modules/welcome/views/templates/credits.hbs
+++ b/app/modules/welcome/views/templates/credits.hbs
@@ -31,5 +31,5 @@
 
   <h4>{{I18n 'association'}}</h4>
   <p><a href="https://wiki.inventaire.io/wiki/Legal-notice">{{I18n 'legal notice'}}</a></p>
-  <p><a href="https://wiki.inventaire.io/wiki/Statuts">{{I18n 'statuses'}}</a></p>
+  <p><a href="https://wiki.inventaire.io/wiki/Statuses">{{I18n 'statuses'}}</a></p>
 </section>


### PR DESCRIPTION
I also believe the anchor text should be "statutes" in English, but don't know where to change that