### PR TITLE
experimentation on how to reuse entities data from another instance

### DIFF
--- a/app/api/entities.js
+++ b/app/api/entities.js
@@ -4,17 +4,26 @@ const { action } = endpoint('entities')
 
 const CustomQuery = actionName => (uri, refresh) => action(actionName, { uri, refresh })
 
+const customizeInstance = url => {
+  if (app.config.remoteEntities != null) {
+    return `${app.config.remoteEntities}${url}`
+  } else {
+    return url
+  }
+}
+
 export default {
   // GET
   getByUris (uris, refresh, relatives) {
     uris = forceArray(uris).join('|')
     const autocreate = true
     if (relatives != null) relatives = forceArray(relatives).join('|')
-    return action('by-uris', { uris, refresh, relatives, autocreate })
+    const url = action('by-uris', { uris, refresh, relatives, autocreate })
+    return customizeInstance(url)
   },
 
   // Get many by POSTing URIs in the body
-  getManyByUris: action('by-uris'),
+  getManyByUris: () => customizeInstance(action('by-uris')),
 
   reverseClaims (property, value, refresh, sort) {
     return action('reverse-claims', { property, value, refresh, sort })

--- a/app/api/entities.js
+++ b/app/api/entities.js
@@ -3,7 +3,7 @@ import endpoint from './endpoint'
 import { customizeInstance } from './instance'
 const { action } = endpoint('entities')
 
-const CustomQuery = actionName => (uri, refresh) => action(actionName, { uri, refresh })
+const CustomQuery = actionName => (uri, refresh) => customizeInstance(action(actionName, { uri, refresh }))
 
 export default {
   // GET
@@ -19,7 +19,7 @@ export default {
   getManyByUris: () => customizeInstance(action('by-uris')),
 
   reverseClaims (property, value, refresh, sort) {
-    return action('reverse-claims', { property, value, refresh, sort })
+    return customizeInstance(action('reverse-claims', { property, value, refresh, sort }))
   },
 
   authorWorks: CustomQuery('author-works'),
@@ -28,12 +28,12 @@ export default {
 
   images (uris, refresh) {
     uris = forceArray(uris).join('|')
-    return action('images', { uris, refresh })
+    return customizeInstance(action('images', { uris, refresh }))
   },
 
-  activity: period => action('activity', { period }),
+  activity: period => customizeInstance(action('activity', { period })),
   changes: action('changes'),
-  history: id => action('history', { id }),
+  history: id => customizeInstance(action('history', { id })),
 
   // POST
   create: action('create'),
@@ -55,7 +55,7 @@ export default {
   delete: action('delete'),
   duplicates: action('duplicates'),
   contributions (userId, limit, offset) {
-    return action('contributions', { user: userId, limit, offset })
+    return customizeInstance(action('contributions', { user: userId, limit, offset }))
   },
   moveToWikidata: action('move-to-wikidata')
 }

--- a/app/api/entities.js
+++ b/app/api/entities.js
@@ -1,16 +1,9 @@
 import { forceArray } from 'lib/utils'
 import endpoint from './endpoint'
+import { customizeInstance } from './instance'
 const { action } = endpoint('entities')
 
 const CustomQuery = actionName => (uri, refresh) => action(actionName, { uri, refresh })
-
-const customizeInstance = url => {
-  if (app.config.remoteEntities != null) {
-    return `${app.config.remoteEntities}${url}`
-  } else {
-    return url
-  }
-}
 
 export default {
   // GET

--- a/app/api/img.js
+++ b/app/api/img.js
@@ -2,6 +2,7 @@ import { isNonEmptyString, isEntityUri, isAssetImg, isLocalImg, isImageHash } fr
 import { fixedEncodeURIComponent, hashCode } from 'lib/utils'
 import { buildPath } from 'lib/location'
 import commons_ from 'lib/wikimedia/commons'
+import { customizeInstance } from './instance'
 
 // Keep in sync with server/lib/emails/app_api
 export default function (path, width = 1600, height = 1600) {
@@ -10,7 +11,9 @@ export default function (path, width = 1600, height = 1600) {
   // Converting image hashes to a full URL
   if (isLocalImg(path) || isAssetImg(path)) {
     const [ container, filename ] = path.split('/').slice(2)
-    return `/img/${container}/${width}x${height}/${filename}`
+    const url = `/img/${container}/${width}x${height}/${filename}`
+    if (container === 'entities') return customizeInstance(url)
+    else return url
   }
 
   // The server may return images path on upload.wikimedia.org

--- a/app/api/instance.js
+++ b/app/api/instance.js
@@ -1,0 +1,7 @@
+export const customizeInstance = url => {
+  if (app.config.remoteEntities != null) {
+    return `${app.config.remoteEntities}${url}`
+  } else {
+    return url
+  }
+}

--- a/app/api/search.js
+++ b/app/api/search.js
@@ -1,11 +1,17 @@
 import { forceArray } from 'lib/utils'
 import { buildPath } from 'lib/location'
 import endpoint from './endpoint'
+import { customizeInstance } from './instance'
+
 const { base } = endpoint('search')
 
 export default function (types, search, limit = 10, exact = false) {
   const { lang } = app.user
-  types = forceArray(types).join('|')
+  types = forceArray(types)
+  const hasSocialTypes = types.includes('users') || types.includes('groups')
+  types = types.join('|')
   search = encodeURIComponent(search)
-  return buildPath(base, { types, search, lang, limit, exact })
+  const url = buildPath(base, { types, search, lang, limit, exact })
+  if (hasSocialTypes) return url
+  else return customizeInstance(url)
 }

--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -45,7 +45,7 @@ export const getEntitiesByUris = async params => {
     res = await preq.get(app.API.entities.getByUris(uris))
   } else {
     // Use the POST endpoint when using a GET might hit some URI length limits
-    res = await preq.post(app.API.entities.getManyByUris, { uris })
+    res = await preq.post(app.API.entities.getManyByUris(), { uris })
   }
   const { entities } = res
   const serializedEntities = Object.values(entities).map(serializeEntity)

--- a/app/modules/entities/lib/entities_models_index.js
+++ b/app/modules/entities/lib/entities_models_index.js
@@ -68,7 +68,7 @@ const getRemoteEntitiesModels = function (uris, refresh, defaultType) {
     promise = preq.get(app.API.entities.getByUris(uris, refresh))
   } else {
     // Use the POST endpoint when using a GET might hit some URI length limits
-    promise = preq.post(app.API.entities.getManyByUris, { uris, refresh })
+    promise = preq.post(app.API.entities.getManyByUris(), { uris, refresh })
   }
 
   return promise

--- a/app/modules/user/models/main_user.js
+++ b/app/modules/user/models/main_user.js
@@ -43,8 +43,9 @@ export default UserCommons.extend({
     this.setDefaultPicture()
     const accessLevels = this.get('accessLevels')
     if (accessLevels == null) return
-    this.hasAdminAccess = accessLevels.includes('admin')
-    this.hasDataadminAccess = accessLevels.includes('dataadmin')
+    const clientUsesLocalEntities = app.config.remoteEntities == null
+    this.hasAdminAccess = accessLevels.includes('admin') && clientUsesLocalEntities
+    this.hasDataadminAccess = accessLevels.includes('dataadmin') && clientUsesLocalEntities
   },
 
   // Two valid language change cases:


### PR DESCRIPTION
client part of https://github.com/inventaire/inventaire/pull/548

When the server sends a `remoteEntities` URL in the client config ([`/api/config`](https://inventaire.io/api/config))
* Fetches entities data from that remote instance (made possible by the open CORS policy https://github.com/inventaire/inventaire/pull/543)
* Uses entities images from that remote instance
* Searches entities on that remote instance
* Disable `admin` and `dataadmin` views (as those rights apply to the local entities, but can't be assumed for the remote instance)