### PR TITLE
fix search section bug

### DIFF
--- a/app/modules/general/scss/_top_bar.scss
+++ b/app/modules/general/scss/_top_bar.scss
@@ -1,4 +1,4 @@
-$search-section-width: 6em;
+$search-section-width: 7em;
 $top-bar-fixed-threshold: 340px;
 
 nav#top-bar{


### PR DESCRIPTION
i18n commit b2848fd88 introduced a long word ("maison d'édition" which indeed is a better designation than the cold and gendered "éditeur") which breaks the french version of search sections (no other languages have been affected by the same problem)
Subjects section is pushed to a new line, which is a terrible behavior affecting a menu that is already quite complex to apprehend

this commit is a quick fix to solve this problem:
- expand slightly section size (i said quick fix :)
- prevent any section to go to a new line, and rather fallback on stacking words on top of each other (default flex behavior)
