### PR TITLE
Recover email validation request

### DIFF
--- a/app/modules/settings/components/account.svelte
+++ b/app/modules/settings/components/account.svelte
@@ -128,6 +128,7 @@
     <button class="light-blue-button" on:click="{updateEmail}">{I18n('update email')}</button>
 
     {#if !$user.validEmail}
+      <h3 class="label">{I18n('unverified email')}</h3>
       <EmailValidation />
     {/if}
 

--- a/app/modules/settings/components/account.svelte
+++ b/app/modules/settings/components/account.svelte
@@ -3,6 +3,7 @@
   import preq from 'lib/preq'
   import _ from 'underscore'
   import Flash from 'lib/components/flash.svelte'
+  import EmailValidation from './email_validation.svelte'
   import UpdatePassword from 'lib/components/update_password.svelte'
   import languagesObj from 'lib/languages_data'
   import email_ from 'modules/user/lib/email_tests'
@@ -125,6 +126,10 @@
     <Flash bind:state={flashEmail}/>
     <p class="note">{I18n('email will not be publicly displayed.')}</p>
     <button class="light-blue-button" on:click="{updateEmail}">{I18n('update email')}</button>
+
+    {#if !$user.validEmail}
+      <EmailValidation />
+    {/if}
 
     <h3>{I18n('password')}</h3>
     <UpdatePassword/>

--- a/app/modules/settings/components/email_validation.svelte
+++ b/app/modules/settings/components/email_validation.svelte
@@ -1,0 +1,68 @@
+<script>
+  import { icon } from 'lib/utils'
+  import { I18n } from 'modules/user/lib/i18n'
+
+  let validationEmailRequested = false
+
+  async function emailConfirmationRequest () {
+    validationEmailRequested = true
+    try {
+      await app.request('email:confirmation:request')
+    } catch (err) {
+      validationEmailRequested = false
+      throw err
+    }
+  }
+</script>
+
+<div class="emailValidation">
+  {#if validationEmailRequested}
+    <div id="confirmationEmailSent" class="successMessageBox">
+      {@html icon('check')}
+      {@html I18n('new_confirmation_email')}
+    </div>
+  {:else}
+    <div id="notValidEmail">
+      {@html icon('warning')}
+      {@html I18n('email_wasnt_verified')}
+    </div>
+    <button class="button dark-grey radius" on:click={emailConfirmationRequest}>
+      {@html I18n('email_confirmation_error_button')}
+    </button>
+  {/if}
+</div>
+
+<style lang="scss">
+  @import 'app/modules/general/scss/utils';
+
+  .emailValidation{
+    background-color: $soft-grey;
+    @include radius;
+    padding: 1em;
+    margin: 1em 0;
+  }
+
+  #notValidEmail, #confirmationEmailSent{
+    color: white;
+    text-align: center;
+  }
+
+  button{
+    @include radius;
+    display: block;
+    margin: 1em auto 0 auto;
+  }
+
+  #notValidEmail{
+    width: 100%;
+    background-color: $warning-color;
+    padding: 0.5em;
+    margin: 1em 0;
+  }
+
+  #confirmationEmailSent{
+    @include radius;
+    background-color: $success-color;
+    padding: 0.5em;
+  }
+</style>

--- a/app/modules/settings/components/email_validation.svelte
+++ b/app/modules/settings/components/email_validation.svelte
@@ -15,54 +15,17 @@
   }
 </script>
 
-<div class="emailValidation">
-  {#if validationEmailRequested}
-    <div id="confirmationEmailSent" class="successMessageBox">
-      {@html icon('check')}
-      {@html I18n('new_confirmation_email')}
-    </div>
-  {:else}
-    <div id="notValidEmail">
-      {@html icon('warning')}
-      {@html I18n('email_wasnt_verified')}
-    </div>
-    <button class="button dark-grey radius" on:click={emailConfirmationRequest}>
-      {@html I18n('email_confirmation_error_button')}
-    </button>
-  {/if}
-</div>
-
-<style lang="scss">
-  @import 'app/modules/general/scss/utils';
-
-  .emailValidation{
-    background-color: $soft-grey;
-    @include radius;
-    padding: 1em;
-    margin: 1em 0;
-  }
-
-  #notValidEmail, #confirmationEmailSent{
-    color: white;
-    text-align: center;
-  }
-
-  button{
-    @include radius;
-    display: block;
-    margin: 1em auto 0 auto;
-  }
-
-  #notValidEmail{
-    width: 100%;
-    background-color: $warning-color;
-    padding: 0.5em;
-    margin: 1em 0;
-  }
-
-  #confirmationEmailSent{
-    @include radius;
-    background-color: $success-color;
-    padding: 0.5em;
-  }
-</style>
+{#if validationEmailRequested}
+  <p>
+    {@html icon('check')}
+    {@html I18n('new_confirmation_email')}
+  </p>
+{:else}
+  <p>
+    {@html icon('warning')}
+    {@html I18n('email_wasnt_verified')}
+  </p>
+  <button class="light-blue-button radius" on:click={emailConfirmationRequest}>
+    {@html I18n('email_confirmation_error_button')}
+  </button>
+{/if}

--- a/app/modules/user/views/templates/valid_email_confirmation.hbs
+++ b/app/modules/user/views/templates/valid_email_confirmation.hbs
@@ -5,7 +5,7 @@
       {{I18n 'email_confirmation_success'}}
     </p>
     {{#if loggedIn}}
-      <a href="/inventory" class="button dark-grey radius showHome">
+      <a href="{{inventoryPath}}" class="button dark-grey radius showHome">
         {{I18n 'back to your inventory'}}
       </a>
     {{else}}

--- a/app/modules/user/views/valid_email_confirmation.js
+++ b/app/modules/user/views/valid_email_confirmation.js
@@ -3,6 +3,7 @@ import validEmailConfirmationTemplate from './templates/valid_email_confirmation
 import '../scss/valid_email_confirmation.scss'
 import General from 'behaviors/general'
 import Loading from 'behaviors/loading'
+import PreventDefault from 'behaviors/prevent_default'
 import SuccessCheck from 'behaviors/success_check'
 
 export default Marionette.View.extend({
@@ -11,11 +12,12 @@ export default Marionette.View.extend({
   behaviors: {
     Loading,
     General,
+    PreventDefault,
     SuccessCheck,
   },
 
   events: {
-    'click .showHome, .showLoginRedirectSettings' () { app.execute('modal:close') },
+    'click .showHome': 'showHome',
     'click .showLoginRedirectSettings': 'showLoginRedirectSettings',
     'click #emailConfirmationRequest': 'emailConfirmationRequest'
   },
@@ -27,7 +29,8 @@ export default Marionette.View.extend({
   serializeData () {
     return {
       validEmail: this.options.validEmail,
-      loggedIn: app.user.loggedIn
+      loggedIn: app.user.loggedIn,
+      inventoryPath: app.user.get('pathname'),
     }
   },
 
@@ -40,7 +43,13 @@ export default Marionette.View.extend({
 
   showLoginRedirectSettings () {
     app.request('show:login:redirect', 'settings/profile')
-  }
+    app.execute('modal:close')
+  },
+
+  showHome () {
+    app.execute('show:home')
+    app.execute('modal:close')
+  },
 })
 
 const emailFail = function () {


### PR DESCRIPTION
It use to be possible to request a new email with a token to validation the user email address; that was lost when the settings got rewritten in Svelte, and this PR brings that back