### PR TITLE
improve entities homonyms search

### DIFF
--- a/app/modules/entities/lib/show_homonyms.js
+++ b/app/modules/entities/lib/show_homonyms.js
@@ -2,73 +2,20 @@ import preq from '#lib/preq'
 import Entities from '../collections/entities.js'
 import loader from '#general/views/templates/loader.hbs'
 
-const entitiesTypesWithTasks = [
-  'human'
-]
-
 export default async params => {
   if (!app.user.hasDataadminAccess) return
   const { layout, regionName, model, standalone } = params
   layout.getRegion(regionName).$el.html(loader())
 
   const [ entities, { default: MergeHomonyms } ] = await Promise.all([
-    getHomonymsAndTasks(model),
+    getHomonyms(model),
     import('../views/editor/merge_homonyms')
   ])
   const collection = new Entities(entities)
   layout.showChildView(regionName, new MergeHomonyms({ collection, model, standalone }))
 }
 
-const getHomonymsAndTasks = async model => {
-  const tasksEntitiesData = await getTasksByUri(model)
-  const tasksEntitiesUris = _.pluck(tasksEntitiesData, 'uri')
-  const homonymEntities = await getHomonyms(model, tasksEntitiesUris)
-  // returning a mix of raw objects and models
-  return tasksEntitiesData.concat(homonymEntities)
-}
-
-const getTasksByUri = async model => {
-  const type = model.get('type')
-  if (!entitiesTypesWithTasks.includes(type)) return []
-
-  const uri = model.get('uri')
-  const [ action, relation ] = getHomonymsParams(uri)
-  const res = await preq.get(app.API.tasks[action](uri))
-  const tasks = res.tasks[uri]
-  const suggestionsUris = _.pluck(tasks, relation)
-  let entities = await app.request('get:entities:models', { uris: suggestionsUris })
-  // Filter-out redirected entities
-  // Known case: we got an obsolete task
-  entities = entities.filter(entity => suggestionsUris.includes(entity.get('uri')))
-  return addTasksToEntities(uri, tasks, relation, entities)
-}
-
-const getHomonymsParams = uri => {
-  const [ prefix ] = uri.split(':')
-  if (prefix === 'wd') {
-    return [ 'bySuggestionUris', 'suspectUri' ]
-  } else {
-    return [ 'bySuspectUris', 'suggestionUri' ]
-  }
-}
-
-const addTasksToEntities = async (uri, tasks, relation, entities) => {
-  const { default: Task } = await import('#tasks/models/task')
-
-  const tasksIndex = _.indexBy(tasks, relation)
-
-  entities.forEach(entity => {
-    if (!entity.tasks) entity.tasks = {}
-    const task = tasksIndex[entity.get('uri')]
-    entity.tasks[uri] = new Task(task)
-  })
-
-  entities.sort((a, b) => b.tasks[uri].get('globalScore') - a.tasks[uri].get('globalScore'))
-
-  return entities
-}
-
-const getHomonyms = async (model, tasksEntitiesUris) => {
+const getHomonyms = async model => {
   const [ uri, label ] = model.gets('uri', 'label')
   const { pluralizedType } = model
   const { results } = await preq.get(app.API.search({
@@ -77,20 +24,13 @@ const getHomonyms = async (model, tasksEntitiesUris) => {
     limit: 100,
     exact: true
   }))
-  return parseSearchResults(uri, tasksEntitiesUris, results)
+  return parseSearchResults(uri, results)
 }
 
-const parseSearchResults = async (uri, tasksEntitiesUris, searchResults) => {
-  let uris = _.pluck(searchResults, 'uri')
-  const prefix = uri.split(':')[0]
-  if (prefix === 'wd') uris = uris.filter(isntWdUri)
-  // Omit the current entity URI and the entities for which a task was found
-  const urisToOmit = [ uri ].concat(tasksEntitiesUris)
-  uris = _.without(uris, ...urisToOmit)
+const parseSearchResults = async (uri, searchResults) => {
+  const uris = _.pluck(searchResults, 'uri')
   // Search results entities miss their claims, so we need to fetch the full entities
   const entities = await app.request('get:entities:models', { uris })
   // Re-filter out uris to omit as a redirection might have brought it back
-  return entities.filter(entity => !urisToOmit.includes(entity.get('uri')))
+  return entities.filter(entity => entity.get('uri') !== uri)
 }
-
-const isntWdUri = uri => uri.split(':')[0] !== 'wd'

--- a/app/modules/entities/lib/show_homonyms.js
+++ b/app/modules/entities/lib/show_homonyms.js
@@ -16,21 +16,47 @@ export default async params => {
 }
 
 const getHomonyms = async model => {
-  const [ uri, label ] = model.gets('uri', 'label')
+  const [ uri, labels, aliases ] = model.gets('uri', 'labels', 'aliases')
+  const terms = getTerms(labels, aliases)
   const { pluralizedType } = model
-  const { results } = await preq.get(app.API.search({
-    types: pluralizedType,
-    search: label,
-    limit: 100,
-    exact: true
-  }))
+  const responses = await Promise.all(terms.map(searchTerm(pluralizedType)))
+  const results = _.pluck(responses, 'results').flat()
   return parseSearchResults(uri, results)
 }
 
+const searchTerm = types => term => {
+  return preq.get(app.API.search({
+    types,
+    search: term,
+    limit: 100,
+    exact: true
+  }))
+}
+
 const parseSearchResults = async (uri, searchResults) => {
-  const uris = _.pluck(searchResults, 'uri')
+  const uris = _.uniq(_.pluck(searchResults, 'uri'))
+    .filter(result => result.uri !== uri)
   // Search results entities miss their claims, so we need to fetch the full entities
   const entities = await app.request('get:entities:models', { uris })
   // Re-filter out uris to omit as a redirection might have brought it back
   return entities.filter(entity => entity.get('uri') !== uri)
+}
+
+const getTerms = (labels, aliases) => {
+  let terms = Object.values(labels)
+    .concat(Object.values(aliases).flat())
+    // Order term words to not search both "foo bar" and "bar foo"
+    // as words order doesn't matter
+    .map(orderTermWordsAlphabetically)
+  return _.uniq(terms)
+}
+
+const orderTermWordsAlphabetically = term => {
+  return term
+  .toLowerCase()
+  // Remove characters known to create duplicates
+  .replace(/[.]/g, '')
+  .split(' ')
+  .sort((a, b) => a > b ? 1 : -1)
+  .join(' ')
 }

--- a/app/modules/entities/scss/merge_homonyms.scss
+++ b/app/modules/entities/scss/merge_homonyms.scss
@@ -21,6 +21,9 @@
 .inner-merge-homonyms{
   @include display-flex(row, flex-start, center, wrap);
 }
+.fa-wikidata{
+  margin-right: 0.2em;
+}
 .merge-homonym{
   position: relative;
   background-color: white;
@@ -81,6 +84,7 @@
     }
   }
   .merge{
+    font-weight: normal;
     text-align: center;
     padding: 0.5em;
     display: block;

--- a/app/modules/entities/views/editor/merge_homonym.js
+++ b/app/modules/entities/views/editor/merge_homonym.js
@@ -9,6 +9,7 @@ import '#entities/scss/merge_homonyms.scss'
 import AlertBox from '#behaviors/alert_box'
 import Loading from '#behaviors/loading'
 import PreventDefault from '#behaviors/prevent_default'
+import { buildPath } from '#lib/location'
 
 export default Marionette.View.extend({
   template: mergeSuggestionTemplate,
@@ -31,7 +32,15 @@ export default Marionette.View.extend({
       this.isTypeAttribute = `is${capitalize(this.model.type)}`
     }
     this.isExactMatch = haveLabelMatch(this.model, this.options.toEntity)
-    this.showCheckbox = this.options.showCheckbox
+
+    this.wikidataEntities = this.model.get('isWikidataEntity') && this.options.toEntity.get('isWikidataEntity')
+    if (this.wikidataEntities) {
+      const fromid = this.options.toEntity.get('uri').split(':')[1]
+      const toid = this.model.get('uri').split(':')[1]
+      this.wikidataMergeUrl = buildPath('https://www.wikidata.org/wiki/Special:MergeItems', { fromid, toid })
+    }
+
+    this.showCheckbox = this.options.showCheckbox && !this.wikidataEntities
   },
 
   serializeData () {
@@ -40,6 +49,8 @@ export default Marionette.View.extend({
     attrs[this.isTypeAttribute] = true
     attrs.isExactMatch = this.isExactMatch
     attrs.showCheckbox = this.showCheckbox
+    attrs.wikidataEntities = this.wikidataEntities
+    attrs.wikidataMergeUrl = this.wikidataMergeUrl
     return attrs
   },
 

--- a/app/modules/entities/views/editor/templates/merge_homonym.hbs
+++ b/app/modules/entities/views/editor/templates/merge_homonym.hbs
@@ -36,8 +36,11 @@
   <div class="worksList"></div>
 </div>
 
-
-<a class="merge tiny-button dangerous">
-  <span class="hide-on-loading">{{icon 'compress'}}{{I18n 'merge'}}</span>
-  <span class="loading"></span>
-</a>
+{{#if wikidataEntities}}
+  {{iconLinkText name='wikidata' url=wikidataMergeUrl i18n='Merge on Wikidata' linkClasses='tiny-button'}}
+{{else}}
+  <button class="merge tiny-button dangerous">
+    <span class="hide-on-loading">{{icon 'compress'}}{{I18n 'merge'}}</span>
+    <span class="loading"></span>
+  </button>
+{{/if}}


### PR DESCRIPTION
Currently, a dataadmin going on an entity layout (ex: https://inventaire.io/entity/wd:Q181659) is presented with a list of homonyms made of the exact search results associated with only one label (ex: "Ursula K. Le Guin").

This PR proposes to instead search for more terms when available (ex: "Ursula Kroeber Le Guin", "Ursula Le Guin", "Le Guin", etc), letting the dataadmin the chance to find less straight-forward duplicates, such as:
* https://inventaire.io/entity/inv:783a4084e477b0df0a9e30ec5307875e
* https://inventaire.io/entity/inv:9b970c316e70fd16bcf9933e8564ac6f
* https://inventaire.io/entity/inv:f38d6bb78ae4af173a3a9708d7908393
* https://inventaire.io/entity/inv:b0fe2d7f5775e3678709b7040842f879

This PR removes tasks from the homonyms as the added value there was low: only the presence of an external occurrence was providing an information, but tasks with occurrences appearing high in the task layout, they are often processed before having the time to appear in a random visit on the homonyms section: I don't recall seeing a single task with an external occurrence there