### PR TITLE
Fix svelte components lifecycle

### DIFF
--- a/app/lib/global_libs_extender.js
+++ b/app/lib/global_libs_extender.js
@@ -148,10 +148,10 @@ Backbone.View.prototype.ifViewIsIntact = function (fn, ...args) {
 
 const originalShowChildView = Marionette.View.prototype.showChildView
 
-Marionette.View.prototype.showChildView = function (name, view, options) {
+Marionette.View.prototype.showChildView = function (regionName, view, options) {
   if (!this.isIntact()) return
-  originalShowChildView.call(this, name, view, options)
-  const region = this.getRegion(name)
+  originalShowChildView.call(this, regionName, view, options)
+  const region = this.getRegion(regionName)
   const children = region.$el.children()
   if (children.length > 1) removeObsoleteChildren(children)
   return view
@@ -164,6 +164,16 @@ function removeObsoleteChildren (children) {
     // Remove all but the last element
     if (i !== lastIndex) $(el).remove()
   })
+}
+
+Marionette.View.prototype.showChildComponent = function (regionName, Component, options = {}) {
+  if (!this.isIntact()) return
+  const region = this.getRegion(regionName)
+  const el = (typeof region.el === 'string') ? document.querySelector(region.el) : region.el
+  options.target = el
+  // Svelte only appends to the target, thus the need to empty it before mounting
+  $(el).empty()
+  return new Component(options)
 }
 
 Marionette.CollectionView.prototype.showChildView = Marionette.View.prototype.showChildView
@@ -198,14 +208,6 @@ Backbone.View.prototype.lazyRender = function (focusSelector) {
     this._lazyRender = LazyRender(this, delay)
   }
   this._lazyRender(focusSelector)
-}
-
-Marionette.Region.prototype.showSvelteComponent = function (SvelteComponent, options) {
-  const el = (typeof this.el === 'string') ? document.querySelector(this.el) : this.el
-  options.target = el
-  // Svelte only appends to the target, thus the need to empty it before mounting
-  $(el).empty()
-  return new SvelteComponent(options)
 }
 
 const triggerChange = function (model, attr, value) {

--- a/app/lib/global_libs_extender.js
+++ b/app/lib/global_libs_extender.js
@@ -172,6 +172,9 @@ function removeCurrentComponent (region) {
   if (region.currentComponent) {
     region.currentComponent.$destroy()
     delete region.currentComponent
+  } else if (region.currentView?._regions) {
+    const subregions = Object.values(region.currentView._regions)
+    subregions.forEach(removeCurrentComponent)
   }
 }
 

--- a/app/lib/global_libs_extender.js
+++ b/app/lib/global_libs_extender.js
@@ -150,30 +150,29 @@ const originalShowChildView = Marionette.View.prototype.showChildView
 
 Marionette.View.prototype.showChildView = function (regionName, view, options) {
   if (!this.isIntact()) return
-  originalShowChildView.call(this, regionName, view, options)
   const region = this.getRegion(regionName)
-  const children = region.$el.children()
-  if (children.length > 1) removeObsoleteChildren(children)
+  removeCurrentComponent(region)
+  originalShowChildView.call(this, regionName, view, options)
   return view
-}
-
-function removeObsoleteChildren (children) {
-  // The latest view is always appended is must thus be the last element
-  const lastIndex = children.length - 1
-  children.each((i, el) => {
-    // Remove all but the last element
-    if (i !== lastIndex) $(el).remove()
-  })
 }
 
 Marionette.View.prototype.showChildComponent = function (regionName, Component, options = {}) {
   if (!this.isIntact()) return
   const region = this.getRegion(regionName)
+  if (region.currentView) region.currentView.destroy()
+  removeCurrentComponent(region)
   const el = (typeof region.el === 'string') ? document.querySelector(region.el) : region.el
   options.target = el
-  // Svelte only appends to the target, thus the need to empty it before mounting
-  $(el).empty()
-  return new Component(options)
+  const component = new Component(options)
+  region.currentComponent = component
+  return component
+}
+
+function removeCurrentComponent (region) {
+  if (region.currentComponent) {
+    region.currentComponent.$destroy()
+    delete region.currentComponent
+  }
 }
 
 Marionette.CollectionView.prototype.showChildView = Marionette.View.prototype.showChildView

--- a/app/modules/entities/entities.js
+++ b/app/modules/entities/entities.js
@@ -203,7 +203,7 @@ const API = {
     const { from, to, type } = app.request('querystring:get:all')
     app.execute('show:loader')
     const { default: EntityMerge } = await import('./components/entity_merge.svelte')
-    app.layout.getRegion('main').showSvelteComponent(EntityMerge, {
+    app.layout.showChildComponent('main', EntityMerge, {
       props: { from, to, type }
     })
   },
@@ -225,7 +225,7 @@ const showEntityCreate = async params => {
   if (params.claims) app.execute('querystring:set', 'claims', params.claims)
 
   const { default: EntityCreate } = await import('./components/editor/entity_create.svelte')
-  app.layout.getRegion('main').showSvelteComponent(EntityCreate, {
+  app.layout.showChildComponent('main', EntityCreate, {
     props: params
   })
 }
@@ -322,7 +322,7 @@ const showEntityEdit = async params => {
   const { model } = params
   if (model.type == null) throw error_.new('invalid entity type', model)
   const { default: EntityEdit } = await import('./components/editor/entity_edit.svelte')
-  app.layout.getRegion('main').showSvelteComponent(EntityEdit, {
+  app.layout.showChildComponent('main', EntityEdit, {
     props: {
       entity: model.toJSON()
     }
@@ -382,7 +382,7 @@ const showEntityCreateFromIsbn = async isbn => {
   }
 
   const { default: EntityCreateEditionAndWorkFromIsbn } = await import('./components/editor/entity_create_edition_and_work_from_isbn.svelte')
-  app.layout.getRegion('main').showSvelteComponent(EntityCreateEditionAndWorkFromIsbn, {
+  app.layout.showChildComponent('main', EntityCreateEditionAndWorkFromIsbn, {
     props: {
       isbn13h,
       edition: { claims }
@@ -413,7 +413,7 @@ const showViewByAccessLevel = function (params) {
       if (View) {
         app.layout.showChildView('main', new View(viewOptions))
       } else {
-        app.layout.getRegion('main').showSvelteComponent(Component, {
+        app.layout.showChildComponent('main', Component, {
           props: componentProps
         })
       }

--- a/app/modules/inventory/views/add/add_layout.js
+++ b/app/modules/inventory/views/add/add_layout.js
@@ -60,7 +60,7 @@ export default Marionette.View.extend({
     if (wait) await wait
     if (tab === 'import') {
       const { default: SvelteImportLayout } = await import('#inventory/components/importer/import_layout.svelte')
-      this.getRegion('content').showSvelteComponent(SvelteImportLayout, {
+      this.showChildComponent('content', SvelteImportLayout, {
         props: {
           isbns: this.options.isbns
         }

--- a/app/modules/settings/settings.js
+++ b/app/modules/settings/settings.js
@@ -30,7 +30,7 @@ const API = {
 const showSettings = async section => {
   if (app.request('require:loggedIn', `settings/${section}`)) {
     const { default: SettingsLayout } = await import('./components/settings_layout.svelte')
-    return app.layout.getRegion('main').showSvelteComponent(SettingsLayout, {
+    return app.layout.showChildComponent('main', SettingsLayout, {
       props: {
         section
       }


### PR DESCRIPTION
Backbone.Marionette takes care of destroying its views' children and Svelte takes care of destroying its child components, but Backbone.Marionette doesn't take care of destroying Svelte's components, letting them hang in memory, never being destroyed.

This can be checked by adding the following to a Svelte component:
```js
  import { onDestroy } from 'svelte'

  let counter = 0
  const interval = setInterval(() => {
    console.log('component was not destroyed yet', counter++)
  }, 1000)

  onDestroy(() => {
    console.log('component was destroyed')
    clearInterval(interval)
  })
```
go to a layout that makes that component be displayed, see in the console that we get the logs at interval, then move to some other non-layout: the logs continue, meaning that the component was not destroyed.

This PR fixes that by attaching instantiated components to their region as `region.currentComponent` to be able to later call `region.currentComponent.$destroy()` when another view is shown