### PR TITLE
Display customizable links to available external resources 

### DIFF
--- a/app/modules/entities/components/editor/claim_editor.svelte
+++ b/app/modules/entities/components/editor/claim_editor.svelte
@@ -10,7 +10,7 @@
   import { isComponentEvent } from '#lib/boolean_tests'
   import { I18n, i18n } from '#user/lib/i18n'
   import { icon } from '#lib/handlebars_helpers/icons'
-  import { currentEditorKey, isNonEmptyClaimValue } from '#entities/components/editor/lib/editors_helpers'
+  import { currentEditorKey, errorMessageFormatter, isNonEmptyClaimValue } from '#entities/components/editor/lib/editors_helpers'
   import Spinner from '#components/spinner.svelte'
 
   export let entity, property, value, index
@@ -80,7 +80,7 @@
         inputValue = savedValue
         dispatch('set', inputValue)
       }
-      flash = err
+      flash = errorMessageFormatter(err)
     }
   }
 

--- a/app/modules/entities/components/editor/entity_edit.svelte
+++ b/app/modules/entities/components/editor/entity_edit.svelte
@@ -1,17 +1,17 @@
 <script>
   import { I18n } from '#user/lib/i18n'
   import LabelsEditor from './labels_editor.svelte'
-  import { propertiesPerType } from '#entities/lib/editor/properties_per_type'
-  import PropertyClaimsEditor from './property_claims_editor.svelte'
+  import { propertiesPerTypeAndCategory } from '#entities/lib/editor/properties_per_type'
   import getBestLangValue from '#entities/lib/get_best_lang_value'
   import { loadInternalLink } from '#lib/utils'
   import EntityEditMenu from './entity_edit_menu.svelte'
+  import PropertyCategory from '#entities/components/editor/property_category.svelte'
 
   export let entity
 
   const { uri, type, labels } = entity
-  const typeProperties = propertiesPerType[type]
-  const hasMonolingualTitle = typeProperties['wdt:P1476'] != null
+  const typePropertiesPerCategory = propertiesPerTypeAndCategory[type]
+  const hasMonolingualTitle = typePropertiesPerCategory.general['wdt:P1476'] != null
 
   let favoriteLabel
   $: {
@@ -42,11 +42,8 @@
     <LabelsEditor {entity} bind:favoriteLabel />
   {/if}
 
-  {#each Object.keys(typeProperties) as property}
-    <PropertyClaimsEditor
-      bind:entity
-      {property}
-    />
+  {#each Object.entries(typePropertiesPerCategory) as [ category, categoryProperties ]}
+    <PropertyCategory {entity} {category} {categoryProperties} />
   {/each}
 </div>
 

--- a/app/modules/entities/components/editor/external_id_value_display.svelte
+++ b/app/modules/entities/components/editor/external_id_value_display.svelte
@@ -1,0 +1,37 @@
+<script>
+  import Link from '#lib/components/link.svelte'
+  import { I18n } from '#user/lib/i18n'
+  import { createEventDispatcher } from 'svelte'
+  import Tooltip from '#components/tooltip.svelte'
+  import { externalIdsUrlFormatters } from '#entities/components/editor/lib/external_ids_url_formatters'
+
+  export let value, property
+
+  const url = externalIdsUrlFormatters[property](value)
+
+  const dispatch = createEventDispatcher()
+</script>
+
+<button class="value-display" on:click={() => dispatch('edit')} title={I18n('edit')}>
+  <Tooltip>
+    <div slot="primary" aria-haspopup="menu">
+      {value || ''}
+    </div>
+    <div slot="tooltip-content" role="menuitem">
+      <Link {url} text={url} />
+    </div>
+  </Tooltip>
+</button>
+
+<style lang="scss">
+  @import '#general/scss/utils';
+  .value-display{
+    flex: 1;
+    align-self: stretch;
+    cursor: pointer;
+    text-align: left;
+    @include bg-hover(white, 5%);
+    user-select: text;
+    font-weight: normal;
+  }
+</style>

--- a/app/modules/entities/components/editor/lib/editors.js
+++ b/app/modules/entities/components/editor/lib/editors.js
@@ -9,6 +9,7 @@ import SimpleDayValueInput from '../simple_day_value_input.svelte'
 import PositiveIntegerValueInput from '../positive_integer_value_input.svelte'
 import ImageValueInput from '../image_value_input.svelte'
 import ImageValueDisplay from '../image_value_display.svelte'
+import ExternalIdValueDisplay from '../external_id_value_display.svelte'
 
 export const editors = {
   entity: {
@@ -19,6 +20,10 @@ export const editors = {
   string: {
     InputComponent: StringValueInput,
     DisplayComponent: StringValueDisplay,
+  },
+  'external-id': {
+    InputComponent: StringValueInput,
+    DisplayComponent: ExternalIdValueDisplay,
   },
   url: {
     InputComponent: UrlValueInput,

--- a/app/modules/entities/components/editor/lib/editors_helpers.js
+++ b/app/modules/entities/components/editor/lib/editors_helpers.js
@@ -1,3 +1,4 @@
+import { i18n } from '#user/lib/i18n'
 import { writable } from 'svelte/store'
 import wdLang from 'wikidata-lang'
 const { byCode: langByCode } = wdLang
@@ -25,3 +26,11 @@ export function isEmptyClaimValue (value) {
 export const isNonEmptyClaimValue = value => !isEmptyClaimValue(value)
 
 export const currentEditorKey = writable(null)
+
+export function errorMessageFormatter (err) {
+  if (err.message === 'this property value is already used') {
+    const uri = err.responseJSON.context.entity
+    err.html = `${i18n(err.message)}: <a href="/entity/${uri}" class="link">${uri}</a>`
+  }
+  return err
+}

--- a/app/modules/entities/components/editor/lib/external_ids_url_formatters.js
+++ b/app/modules/entities/components/editor/lib/external_ids_url_formatters.js
@@ -1,0 +1,22 @@
+export const externalIdsUrlFormatters = {
+  'wdt:P268': id => `https://catalogue.bnf.fr/ark:/12148/cb${id}`,
+  'wdt:P648': id => {
+    const lastLetter = id.slice(-1)[0]
+    const section = openLibrarySectionByLetter[lastLetter]
+    return `https://openlibrary.org/${section}/${id}`
+  },
+  'wdt:P2002': id => `https://twitter.com/${id}`,
+  'wdt:P2013': id => `https://www.facebook.com/${id}`,
+  'wdt:P2003': id => `https://www.instagram.com/$${id}`,
+  'wdt:P2397': id => `https://www.youtube.com/channel/${id}`,
+  'wdt:P4033': id => {
+    const [ username, host ] = id.split('@')
+    return `https://${host}/@${username}`
+  },
+}
+
+const openLibrarySectionByLetter = {
+  A: 'authors',
+  W: 'works',
+  M: 'books',
+}

--- a/app/modules/entities/components/editor/property_category.svelte
+++ b/app/modules/entities/components/editor/property_category.svelte
@@ -1,0 +1,79 @@
+<script>
+  import { propertiesCategories } from '#entities/lib/editor/properties_per_type'
+  import { I18n } from '#user/lib/i18n'
+  import PropertyClaimsEditor from './property_claims_editor.svelte'
+  import { icon } from '#lib/handlebars_helpers/icons'
+
+  export let entity, category, categoryProperties
+
+  const { label: categoryLabel } = (propertiesCategories[category] || {})
+
+  let showProperties = categoryLabel == null
+  let scrollMarkerEl
+
+  const id = `${category}-category-properties`
+
+  function scroll () {
+    scrollMarkerEl.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' })
+  }
+
+  function toggle () {
+    showProperties = !showProperties
+    if (showProperties) {
+      // Wait for transitions to be over before attempting to scroll
+      setTimeout(scroll, 200)
+    }
+  }
+</script>
+
+{#if categoryLabel}
+  <button
+    aria-controls={id}
+    class:active={showProperties}
+    on:click={toggle}
+    >
+    {@html icon('caret-right')}
+    <h3>{I18n(categoryLabel)}</h3>
+    <div class="scroll-marker" bind:this={scrollMarkerEl}></div>
+  </button>
+{/if}
+
+{#if showProperties}
+  <div {id} class="category-properties">
+    {#each Object.keys(categoryProperties) as property}
+      <PropertyClaimsEditor
+        bind:entity
+        {property}
+      />
+    {/each}
+  </div>
+{/if}
+
+<style lang="scss">
+  @import '#general/scss/utils';
+
+  button{
+    @include display-flex(row, center, flex-start);
+    @include bg-hover($light-grey, 5%);
+    @include radius;
+    margin: 1em 0 0.5em 0;
+    :global(.fa){
+      font-size: 1.6rem;
+      @include transition(transform, 0.2s);
+      color: $grey;
+    }
+    h3{
+      margin: 0;
+    }
+    &.active{
+      :global(.fa){
+        transform: rotate(90deg);
+      }
+    }
+    position: relative;
+  }
+  .scroll-marker{
+    position: absolute;
+    top: -$topbar-height - 10;
+  }
+</style>

--- a/app/modules/entities/components/editor/property_category.svelte
+++ b/app/modules/entities/components/editor/property_category.svelte
@@ -3,12 +3,15 @@
   import { I18n } from '#user/lib/i18n'
   import PropertyClaimsEditor from './property_claims_editor.svelte'
   import { icon } from '#lib/handlebars_helpers/icons'
+  import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
 
   export let entity, category, categoryProperties
 
   const { label: categoryLabel } = (propertiesCategories[category] || {})
 
-  let showProperties = categoryLabel == null
+  let showCategory = getLocalStorageStore(`property_category:${category}:show`)
+  if (categoryLabel == null) $showCategory = true
+
   let scrollMarkerEl
 
   const id = `${category}-category-properties`
@@ -18,18 +21,19 @@
   }
 
   function toggle () {
-    showProperties = !showProperties
-    if (showProperties) {
+    $showCategory = !$showCategory
+    if ($showCategory) {
       // Wait for transitions to be over before attempting to scroll
       setTimeout(scroll, 200)
     }
   }
 </script>
 
+
 {#if categoryLabel}
   <button
     aria-controls={id}
-    class:active={showProperties}
+    class:active={$showCategory}
     on:click={toggle}
     >
     {@html icon('caret-right')}
@@ -38,7 +42,7 @@
   </button>
 {/if}
 
-{#if showProperties}
+{#if $showCategory}
   <div {id} class="category-properties">
     {#each Object.keys(categoryProperties) as property}
       <PropertyClaimsEditor

--- a/app/modules/entities/components/editor/property_claims_editor.svelte
+++ b/app/modules/entities/components/editor/property_claims_editor.svelte
@@ -62,7 +62,7 @@
     class="editor-section"
     class:fixed
     class:missing-required={isRequiredAndMissing}
-    transition:slide
+    transition:slide={{ duration: 100 }}
     >
     {#if isRequiredAndMissing}
       <span class="required-notice">{I18n('required')}</span>

--- a/app/modules/entities/components/layouts/base_layout.svelte
+++ b/app/modules/entities/components/layouts/base_layout.svelte
@@ -8,6 +8,7 @@
   import Link from '#lib/components/link.svelte'
   import { icon as iconFn } from '#lib/handlebars_helpers/icons'
   import Flash from '#lib/components/flash.svelte'
+  import { entityTypeNameBySingularType } from '#entities/lib/types/entities_types'
 
   export let entity, flash
 
@@ -33,7 +34,7 @@
 <div class="layout">
   <div class="header-wrapper">
     <div class="header">
-      <h2 class="type">{I18n(type)}</h2>
+      <h2 class="type">{I18n(entityTypeNameBySingularType[type])}</h2>
     </div>
     <div class="edit-data-actions">
       <Dropdown

--- a/app/modules/entities/components/layouts/entity_claim_link.svelte
+++ b/app/modules/entities/components/layouts/entity_claim_link.svelte
@@ -1,0 +1,9 @@
+<script>
+  import { externalIdsUrlFormatters } from '#entities/components/editor/lib/external_ids_url_formatters'
+  import Link from '#lib/components/link.svelte'
+  export let label, property, value
+
+  const url = externalIdsUrlFormatters[property](value)
+</script>
+
+<Link {url} text={label} classNames="link" />

--- a/app/modules/entities/components/layouts/entity_claim_link.svelte
+++ b/app/modules/entities/components/layouts/entity_claim_link.svelte
@@ -6,4 +6,5 @@
   const url = externalIdsUrlFormatters[property](value)
 </script>
 
-<Link {url} text={label} classNames="link" />
+<!-- TODO: set an icon instead of a text -->
+<Link {url} text={label} title={label} classNames="link" />

--- a/app/modules/entities/components/layouts/entity_claims_links.svelte
+++ b/app/modules/entities/components/layouts/entity_claims_links.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { categoryLabels, displayedPropertiesByCategory } from '#entities/lib/entity_links'
+  import EntityClaimLink from '#entities/components/layouts/entity_claim_link.svelte'
+
+  export let claims
+
+  let categories = {}
+  $: {
+    for (const [ category, propertiesData ] of Object.entries($displayedPropertiesByCategory)) {
+      categories[category] = []
+      for (const propertyData of propertiesData) {
+        const { property } = propertyData
+        if (claims[property]) {
+          categories[category].push({ ...propertyData, value: claims[property][0] })
+        }
+      }
+    }
+  }
+</script>
+
+<div class="entity-claims-links">
+  {#each Object.entries(categories) as [ category, propertiesData ]}
+    {#if propertiesData.length > 0}
+      <p class="category">
+        <span class="category-label">{categoryLabels[category]}:</span>
+        {#each propertiesData as { property, label, value }}
+          <EntityClaimLink {property} {label} {value} />
+        {/each}
+      </p>
+    {/if}
+  {/each}
+</div>
+
+<style lang="scss">
+  @import '#general/scss/utils';
+  .category-label{
+    color: $label-grey;
+  }
+</style>

--- a/app/modules/entities/components/layouts/infobox.svelte
+++ b/app/modules/entities/components/layouts/infobox.svelte
@@ -6,6 +6,7 @@
   import WrapToggler from '#components/wrap_toggler.svelte'
   import Spinner from '#general/components/spinner.svelte'
   import { infoboxPropsLists } from '#entities/components/lib/claims_helpers'
+  import EntityClaimsLinks from '#entities/components/layouts/entity_claims_links.svelte'
 
   export let claims = {},
     relatedEntities = {},
@@ -89,6 +90,7 @@
           />
         {/if}
       {/each}
+      <EntityClaimsLinks claims={claims} />
     </div>
     {#if displayToggler}
       <WrapToggler

--- a/app/modules/entities/lib/editor/properties_per_type.js
+++ b/app/modules/entities/lib/editor/properties_per_type.js
@@ -24,6 +24,8 @@ const work = {
   'wdt:P144': {}, // based on
   'wdt:P941': {}, // inspired by
   'wdt:P856': {}, // official website
+  'wdt:P268': {}, // BNF ID
+  'wdt:P648': {}, // Open Library ID
   ...socialNetworks,
   // 'wdt:P31: {}' # instance of (=> works aliases)
   // 'wdt:P110': {} # illustrator
@@ -53,7 +55,9 @@ export const propertiesPerType = {
     'wdt:P2679': {}, // author of foreword
     'wdt:P2680': {}, // author of afterword
     'wdt:P1104': {}, // number of pages
-    'wdt:P2635': { customLabel: 'number of volumes' }
+    'wdt:P2635': { customLabel: 'number of volumes' },
+    'wdt:P268': {}, // BNF ID
+    'wdt:P648': {}, // Open Library ID
   },
 
   human: {
@@ -63,6 +67,8 @@ export const propertiesPerType = {
     'wdt:P570': {}, // date of death
     'wdt:P737': {}, // influenced by
     'wdt:P856': {}, // official website
+    'wdt:P268': {}, // BNF ID,
+    'wdt:P648': {}, // Open Library ID
     ...socialNetworks
   },
 
@@ -80,6 +86,7 @@ export const propertiesPerType = {
     'wdt:P576': { customLabel: 'date of dissolution' }, // inception
     // Maybe, ISBN publisher prefix shouldn't be displayed but only used for administration(?)
     'wdt:P3035': {}, // ISBN publisher
+    'wdt:P268': {}, // BNF ID
     ...socialNetworks,
   },
 
@@ -89,6 +96,7 @@ export const propertiesPerType = {
     'wdt:P123': {}, // publisher
     'wdt:P921': {}, // main subject
     'wdt:P856': {}, // official website
+    'wdt:P268': {}, // BNF ID
     ...socialNetworks,
   }
 }
@@ -99,11 +107,16 @@ export const requiredPropertiesPerType = {
 }
 
 export const propertiesCategories = {
-  socialNetworks: { label: 'social networks' }
+  socialNetworks: { label: 'social networks' },
+  bibliographicDatabases: { label: 'bibliographic databases' },
 }
 
 const propertiesPerCategory = {
-  socialNetworks: Object.keys(socialNetworks)
+  socialNetworks: Object.keys(socialNetworks),
+  bibliographicDatabases: [
+    'wdt:P268', // BNF ID
+    'wdt:P648', // Open Library ID
+  ]
 }
 
 const categoryPerProperty = {}

--- a/app/modules/entities/lib/editor/properties_per_type.js
+++ b/app/modules/entities/lib/editor/properties_per_type.js
@@ -97,3 +97,30 @@ export const requiredPropertiesPerType = {
   edition: [ 'wdt:P629', 'wdt:P1476', 'wdt:P407' ],
   collection: [ 'wdt:P1476', 'wdt:P123' ]
 }
+
+export const propertiesCategories = {
+  socialNetworks: { label: 'social networks' }
+}
+
+const propertiesPerCategory = {
+  socialNetworks: Object.keys(socialNetworks)
+}
+
+const categoryPerProperty = {}
+
+for (const [ key, categoryData ] of Object.entries(propertiesPerCategory)) {
+  for (const property of categoryData) {
+    categoryPerProperty[property] = key
+  }
+}
+
+export const propertiesPerTypeAndCategory = {}
+
+for (const [ type, propertiesData ] of Object.entries(propertiesPerType)) {
+  propertiesPerTypeAndCategory[type] = {}
+  for (const [ property, propertyData ] of Object.entries(propertiesData)) {
+    const category = categoryPerProperty[property] || 'general'
+    propertiesPerTypeAndCategory[type][category] = propertiesPerTypeAndCategory[type][category] || {}
+    propertiesPerTypeAndCategory[type][category][property] = propertyData
+  }
+}

--- a/app/modules/entities/lib/entity_links.js
+++ b/app/modules/entities/lib/entity_links.js
@@ -1,0 +1,36 @@
+import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
+import { I18n } from '#user/lib/i18n'
+import { derived } from 'svelte/store'
+import { groupBy } from 'underscore'
+
+export const linksSettings = getLocalStorageStore('settings:display:links', [])
+
+const alphabetically = (a, b) => a.label > b.label ? 1 : -1
+
+export const linkClaimsProperties = [
+  { property: 'wdt:P268', label: 'BNF', category: 'bibliographicDatabases' },
+  { property: 'wdt:P648', label: 'OpenLibrary', category: 'bibliographicDatabases' },
+  { property: 'wdt:P2002', label: 'Twitter', category: 'socialNetworks' },
+  { property: 'wdt:P2013', label: 'Facebook', category: 'socialNetworks' },
+  { property: 'wdt:P2003', label: 'Instagram', category: 'socialNetworks' },
+  { property: 'wdt:P2397', label: 'YouTube', category: 'socialNetworks' },
+  { property: 'wdt:P4033', label: 'Mastodon', category: 'socialNetworks' },
+]
+
+export const linksClaimsPropertiesByCategory = groupBy(linkClaimsProperties, 'category')
+
+for (const category of Object.keys(linksClaimsPropertiesByCategory)) {
+  linksClaimsPropertiesByCategory[category] = linksClaimsPropertiesByCategory[category].sort(alphabetically)
+}
+
+export const displayedPropertiesByCategory = derived(linksSettings, $linksSettings => {
+  const displayedProperties = linkClaimsProperties.filter(({ property }) => {
+    return $linksSettings.includes(property)
+  })
+  return groupBy(displayedProperties, 'category')
+})
+
+export const categoryLabels = {
+  bibliographicDatabases: I18n('bibliographic databases'),
+  socialNetworks: I18n('social networks'),
+}

--- a/app/modules/entities/lib/properties.js
+++ b/app/modules/entities/lib/properties.js
@@ -111,18 +111,18 @@ addProp('wdt:P856', 'url', null, false, null)
 
 // # social networks
 // Twitter account
-addProp('wdt:P2002', 'string', null, false, null)
+addProp('wdt:P2002', 'external-id', null, false, null)
 // Facebook account
-addProp('wdt:P2013', 'string', null, false, null)
+addProp('wdt:P2013', 'external-id', null, false, null)
 // Instagram username
-addProp('wdt:P2003', 'string', null, false, null)
+addProp('wdt:P2003', 'external-id', null, false, null)
 // YouTube channel ID
-addProp('wdt:P2397', 'string', null, false, null)
+addProp('wdt:P2397', 'external-id', null, false, null)
 // Mastodon address
-addProp('wdt:P4033', 'string', null, false, null)
+addProp('wdt:P4033', 'external-id', null, false, null)
 
 // # bibliographic databases
 // BNF ID
-addProp('wdt:P268', 'string', null, false, null)
+addProp('wdt:P268', 'external-id', null, false, null)
 // Open Library ID
-addProp('wdt:P648', 'string', null, false, null)
+addProp('wdt:P648', 'external-id', null, false, null)

--- a/app/modules/entities/lib/properties.js
+++ b/app/modules/entities/lib/properties.js
@@ -90,16 +90,6 @@ addProp('wdt:P1412', 'entity', 'languages', true, null)
 addProp('wdt:P737', 'entity', 'humans', true, true)
 // movement
 addProp('wdt:P135', 'entity', 'movements', true, false)
-// Twitter account
-addProp('wdt:P2002', 'string', null, false, null)
-// Facebook account
-addProp('wdt:P2013', 'string', null, false, null)
-// Instagram username
-addProp('wdt:P2003', 'string', null, false, null)
-// YouTube channel ID
-addProp('wdt:P2397', 'string', null, false, null)
-// Mastodon address
-addProp('wdt:P4033', 'string', null, false, null)
 
 // # publisher
 // founded by
@@ -118,3 +108,21 @@ addProp('wdt:P3035', 'string', null, true, null)
 // # all
 // official website
 addProp('wdt:P856', 'url', null, false, null)
+
+// # social networks
+// Twitter account
+addProp('wdt:P2002', 'string', null, false, null)
+// Facebook account
+addProp('wdt:P2013', 'string', null, false, null)
+// Instagram username
+addProp('wdt:P2003', 'string', null, false, null)
+// YouTube channel ID
+addProp('wdt:P2397', 'string', null, false, null)
+// Mastodon address
+addProp('wdt:P4033', 'string', null, false, null)
+
+// # bibliographic databases
+// BNF ID
+addProp('wdt:P268', 'string', null, false, null)
+// Open Library ID
+addProp('wdt:P648', 'string', null, false, null)

--- a/app/modules/settings/components/display.svelte
+++ b/app/modules/settings/components/display.svelte
@@ -1,6 +1,7 @@
 <script>
   import { I18n, i18n } from '#user/lib/i18n'
   import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
+  import DisplayedLinks from '#settings/components/displayed_links.svelte'
 
   const entitiesDisplay = getLocalStorageStore('entitiesDisplay', 'large')
   const inventoryDisplay = getLocalStorageStore('inventoryDisplay', 'cascade')
@@ -22,6 +23,9 @@
       <option value="table">{I18n('table')}</option>
     </select>
   </fieldset>
+
+  <h3>{I18n('links')}</h3>
+  <DisplayedLinks />
 </form>
 
 <style lang="scss">
@@ -34,5 +38,10 @@
   }
   label{
     font-size: 1rem;
+  }
+  h3{
+    font-size: 1.1rem;
+    @include sans-serif;
+    margin-top: 1rem;
   }
 </style>

--- a/app/modules/settings/components/displayed_links.svelte
+++ b/app/modules/settings/components/displayed_links.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { I18n } from '#user/lib/i18n'
+  import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
+
+  const links = getLocalStorageStore('settings:display:links', [])
+
+  const alphabetically = (a, b) => a.label > b.label ? 1 : -1
+
+  const bibliographicDatabases = [
+    { property: 'wdt:P268', label: 'BNF' },
+    { property: 'wdt:P648', label: 'OpenLibrary' },
+  ].sort(alphabetically)
+
+  const socialNetworks = [
+    { property: 'wdt:P2002', label: 'Twitter' },
+    { property: 'wdt:P2013', label: 'Facebook' },
+    { property: 'wdt:P2003', label: 'Instagram' },
+    { property: 'wdt:P2397', label: 'YouTube' },
+    { property: 'wdt:P4033', label: 'Mastodon' },
+  ].sort(alphabetically)
+</script>
+
+<fieldset>
+  <legend>{I18n('bibliographic databases')}</legend>
+  {#each bibliographicDatabases as option}
+    <label>
+      <input type="checkbox" bind:group={$links} value={option.property}>
+      {option.label}
+    </label>
+  {/each}
+</fieldset>
+
+<fieldset>
+  <legend>{I18n('social networks')}</legend>
+  {#each socialNetworks as option}
+    <label>
+      <input type="checkbox" bind:group={$links} value={option.property}>
+      {option.label}
+    </label>
+  {/each}
+</fieldset>
+
+<style lang="scss">
+  @import '#general/scss/utils';
+  fieldset{
+    @include display-flex(row, null, null, wrap);
+  }
+  label{
+    width: 10em;
+    padding: 0.5em;
+    margin: 0.1em;
+    cursor: pointer;
+  }
+</style>

--- a/app/modules/settings/components/displayed_links.svelte
+++ b/app/modules/settings/components/displayed_links.svelte
@@ -1,40 +1,23 @@
 <script>
   import { I18n } from '#user/lib/i18n'
-  import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
-
-  const links = getLocalStorageStore('settings:display:links', [])
-
-  const alphabetically = (a, b) => a.label > b.label ? 1 : -1
-
-  const bibliographicDatabases = [
-    { property: 'wdt:P268', label: 'BNF' },
-    { property: 'wdt:P648', label: 'OpenLibrary' },
-  ].sort(alphabetically)
-
-  const socialNetworks = [
-    { property: 'wdt:P2002', label: 'Twitter' },
-    { property: 'wdt:P2013', label: 'Facebook' },
-    { property: 'wdt:P2003', label: 'Instagram' },
-    { property: 'wdt:P2397', label: 'YouTube' },
-    { property: 'wdt:P4033', label: 'Mastodon' },
-  ].sort(alphabetically)
+  import { linksClaimsPropertiesByCategory, linksSettings } from '#entities/lib/entity_links'
+  const { bibliographicDatabases, socialNetworks } = linksClaimsPropertiesByCategory
 </script>
 
 <fieldset>
   <legend>{I18n('bibliographic databases')}</legend>
   {#each bibliographicDatabases as option}
     <label>
-      <input type="checkbox" bind:group={$links} value={option.property}>
+      <input type="checkbox" bind:group={$linksSettings} value={option.property}>
       {option.label}
     </label>
   {/each}
 </fieldset>
-
 <fieldset>
   <legend>{I18n('social networks')}</legend>
   {#each socialNetworks as option}
     <label>
-      <input type="checkbox" bind:group={$links} value={option.property}>
+      <input type="checkbox" bind:group={$linksSettings} value={option.property}>
       {option.label}
     </label>
   {/each}


### PR DESCRIPTION
The first commits of this PR add the possibility to edit external ids that could not be edited before, such as OpenLibrary or BNF ids.

The next commits use those ids to display links to the corresponding resources. It's a bit rough in the current implementation, it could be made prettier by using the websites icons instead of text(?)

IMO, it makes some sense to have both those features in this PR as they build on the same shared lib: `app/modules/entities/lib/entity_links.js`.
