### PR TITLE
inventory_browser display mode: hide current display mode from options

### DIFF
--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -8,7 +8,7 @@
   import { I18n } from '#user/lib/i18n'
   import { uniqueId } from 'underscore'
 
-  export let value, resetValue = null, options, buttonLabel = null, withImage = false
+  export let value, resetValue = null, options, buttonLabel = null, withImage = false, hideCurrentlySelectedOption = false
   const buttonId = uniqueId('button')
 
   function onKeyDown (e) {
@@ -56,14 +56,16 @@
     </div>
     <div slot="dropdown-content" role="presentation">
       {#each options as option}
-        <button
-          role="option"
-          title={option.text}
-          aria-selected={option.value === value}
-          on:click={() => value = option.value}
-          >
-          <SelectDropdownOption {option} {withImage} />
-        </button>
+        {#if !(hideCurrentlySelectedOption && option.value === value)}
+          <button
+            role="option"
+            title={option.text}
+            aria-selected={option.value === value}
+            on:click={() => value = option.value}
+            >
+            <SelectDropdownOption {option} {withImage} />
+          </button>
+        {/if}
       {/each}
     </div>
   </Dropdown>

--- a/app/modules/inventory/components/inventory_browser_controls.svelte
+++ b/app/modules/inventory/components/inventory_browser_controls.svelte
@@ -75,7 +75,12 @@
         {/await}
       </div>
       <div class="display-controls" transition:slide>
-        <SelectDropdown bind:value={$inventoryDisplay} options={displayOptions} buttonLabel={I18n('display_mode')}/>
+        <SelectDropdown
+          bind:value={$inventoryDisplay}
+          options={displayOptions}
+          buttonLabel={I18n('display_mode')}
+          hideCurrentlySelectedOption={true}
+        />
       </div>
     {/if}
   </div>


### PR DESCRIPTION
as it doesn't bring anything to repeat it when there is just one other option.

Following a UX feedback from @YoannGd 