### PR TITLE
global_search_bar: default to entity:all rather than social:all

### DIFF
--- a/app/modules/search/components/global_search_bar.svelte
+++ b/app/modules/search/components/global_search_bar.svelte
@@ -226,7 +226,9 @@
   let showFallbackLayout
   function onSearchQuery ({ search: text, section, showFallbackLayout: fallback }) {
     searchText = text
-    selectedCategory = sectionsNames.social.includes(section) ? 'social' : 'entity'
+    // Checking on sectionsNames.entity so that 'all' default to 'entity:all'
+    // rather than 'social:all'
+    selectedCategory = sectionsNames.entity.includes(section) ? 'entity' : 'social'
     selectedSection = section
     showFallbackLayout = fallback
   }


### PR DESCRIPTION
fix https://github.com/inventaire/inventaire-client/issues/351