### PR TITLE
Improve map filter display

### DIFF
--- a/app/modules/entities/components/layouts/items_lists.svelte
+++ b/app/modules/entities/components/layouts/items_lists.svelte
@@ -72,16 +72,18 @@
   .map-wrapper{
     // Set to the .simple-map height to allow to scroll to the right level
     // before the map is rendered
+    padding: 0.5em;
     min-height: 30em;
     position: relative;
+    background-color: $off-white;
   }
   .close-map-button{
-    @include position(absolute, 0.2rem, 0.2rem);
+    @include position(absolute, 1rem, 1rem);
     // Above .leaflet-pane
     z-index: 401;
     padding: 0.2rem;
     margin: 0;
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     @include bg-hover(white);
     @include radius;
   }

--- a/app/modules/map/components/items_map.svelte
+++ b/app/modules/map/components/items_map.svelte
@@ -100,9 +100,6 @@
   .loading-wrapper{
     @include display-flex(column, center);
   }
-  .items-map{
-    margin-bottom: 1em;
-  }
   .show-all-button{
     @include tiny-button($light-grey);
     @include text-hover(#333);

--- a/app/modules/map/components/map_filters.svelte
+++ b/app/modules/map/components/map_filters.svelte
@@ -82,24 +82,21 @@
   @import '#general/scss/utils';
   @mixin filter-button($color, $text-color:white){
     color: $dark-grey;
-    background-color: #eee;
+    background-color: white;
+    border-color: $color;
     margin: 0.2em;
     border: 2px solid $light-grey;
     border-radius: 5px;
     @include sans-serif;
     font-weight: normal;
-    &.selected{
-      background-color: white;
-      border-color: $color;
-    }
     &:hover{
-      background-color: #ddd;
+      background-color: $off-white;
       border-color: $color;
     }
   }
   .filters-menu{
     @include display-flex(row, center, space-between);
-    padding: 0.5em 0.5em 0.5em 0.5em;
+    padding: 0.5em;
     background-color: white;
   }
   .left-menu{
@@ -121,8 +118,7 @@
     margin-top: 0.5em;
   }
   .select-filters{
-    @include tiny-button($light-grey);
-    @include text-hover(#333);
+    @include tiny-button($off-white, black);
     margin: 0.2em;
     padding: 0.5em;
   }

--- a/app/modules/map/components/map_filters.svelte
+++ b/app/modules/map/components/map_filters.svelte
@@ -9,6 +9,8 @@
 
   const selectAllFilters = () => { selectedFilters = allFilters }
 
+  const unselectAllFilters = () => { selectedFilters = [] }
+
   // All selectedFilters values must be declared initially, otherwise reset could be incomplete
   selectAllFilters()
 
@@ -59,13 +61,21 @@
     </div>
   </div>
   <div class="right-menu">
-    <button
-      class="select-all-button"
-      on:click={selectAllFilters}
-      disabled={areAllFiltersSelected}
-    >
-      {i18n('Select all filters')}
-    </button>
+    {#if areAllFiltersSelected}
+      <button
+        class="select-filters"
+        on:click={unselectAllFilters}
+      >
+        {i18n('Unselect all filters')}
+      </button>
+    {:else}
+      <button
+        class="select-filters"
+        on:click={selectAllFilters}
+      >
+        {i18n('Select all filters')}
+      </button>
+    {/if}
   </div>
 </div>
 <style lang="scss">
@@ -104,7 +114,7 @@
     color: $label-grey;
     margin-right: 0.5em;
   }
-  .select-all-button{
+  .select-filters{
     @include tiny-button($light-grey);
     @include text-hover(#333);
     margin: 0.2em;

--- a/app/modules/map/components/map_filters.svelte
+++ b/app/modules/map/components/map_filters.svelte
@@ -64,7 +64,7 @@
       on:click={selectAllFilters}
       disabled={areAllFiltersSelected}
     >
-    {i18n('Select all filters', { filters: type })}
+      {i18n('Select all filters')}
     </button>
   </div>
 </div>

--- a/app/modules/map/components/map_filters.svelte
+++ b/app/modules/map/components/map_filters.svelte
@@ -27,19 +27,28 @@
           id="filter-label-{filterValue}"
           for="filter-value-{filterValue}"
         >
-          <span class="filter-box">
-            <input
-              id="filter-value-{filterValue}"
-              type="checkbox"
-              bind:group={selectedFilters}
-              value={filterValue}
+          <input
+            id="filter-value-{filterValue}"
+            type="checkbox"
+            bind:group={selectedFilters}
+            value={filterValue}
+          >
+          {#if filtersData[filterValue].cover}
+            <img
+              class="cover"
+              src={imgSrc(filtersData[filterValue].cover, 128)}
+              alt={filtersData[filterValue].title}
             >
-            {#if filtersData[filterValue].cover}
-              <img class="cover" src={imgSrc(filtersData[filterValue].cover, 128)} alt={filtersData[filterValue].title}>
-            {:else}
-              {I18n(filterValue)}
-            {/if}
-          </span>
+          {:else}
+            <div class="no-cover-data">
+              {#if filtersData[filterValue].title}
+                {filtersData[filterValue].title}
+              {/if}
+              <div class="filter-value">
+                {I18n(filterValue)}
+              </div>
+            </div>
+          {/if}
           {#if filtersData[filterValue].icon}
             <span class="filter-count">
               {@html icon(filtersData[filterValue].icon)}
@@ -87,6 +96,7 @@
     @include display-flex(row, center,flex-start,wrap);
   }
   .filter{
+    @include display-flex(row, center);
     @include filter-button(#ddd);
     padding: 0.5em;
   }
@@ -105,19 +115,24 @@
   #filter-label-selling{ @include filter-button($selling-color); };
   #filter-label-inventorying{ @include filter-button($inventorying-color); };
   .cover{
-    padding: 0.2em;
     font-size: 0.9em;
     max-width: 5em;
-    height: 64px;
   }
   :disabled{
     cursor: not-allowed;
     opacity: 0.5;
   }
+  .no-cover-data{
+    display: inline-block;
+    max-width: 8em;
+  }
+  .filter-value{
+    overflow: hidden;
+  }
   /*Small screens*/
   @media screen and (max-width: 470px) {
     .filters-menu{
-      @include display-flex(column,flex-start);
+      @include display-flex(column, flex-start);
       padding-left: 1em;
     }
     .left-menu{

--- a/app/modules/map/components/map_filters.svelte
+++ b/app/modules/map/components/map_filters.svelte
@@ -16,11 +16,11 @@
 
   $: areAllFiltersSelected = allFilters.every(f => selectedFilters.includes(f))
 </script>
+<div class="filters-title">
+  {i18n(`Filter by ${type}`)}
+</div>
 <div class="filters-menu">
   <div class="left-menu">
-    <span class="filters-title">
-      {i18n(`Filter by ${type}`)}
-    </span>
     <div class="filters">
       {#each allFilters as filterValue}
         <label
@@ -88,16 +88,19 @@
     border-radius: 5px;
     @include sans-serif;
     font-weight: normal;
-    &.selected, &:hover{
+    &.selected{
       background-color: white;
+      border-color: $color;
+    }
+    &:hover{
+      background-color: #ddd;
       border-color: $color;
     }
   }
   .filters-menu{
     @include display-flex(row, center, space-between);
-    padding: 0.5em;
-    padding-left: 1em;
-    background-color: $off-white;
+    padding: 0.5em 0.5em 0.5em 0.5em;
+    background-color: white;
   }
   .left-menu{
     @include display-flex(row, center, flex-start);
@@ -111,8 +114,11 @@
     padding: 0.5em;
   }
   .filters-title{
-    color: $label-grey;
-    margin-right: 0.5em;
+    color: $grey;
+    background-color: white;
+    padding-top: 0.5em;
+    padding-left: 1em;
+    margin-top: 0.5em;
   }
   .select-filters{
     @include tiny-button($light-grey);


### PR DESCRIPTION
Originally improving display of the edition title + uri if no cover available, the PR went a bit forward than this:
- add a possibility to unselect all filters at once
- reorganise filter title position
- put map in a `$off-white` box, to make clear that filter belong to the map