### PR TITLE
item row: add shelf dots

### DIFF
--- a/app/modules/inventory/components/inventory_browser.svelte
+++ b/app/modules/inventory/components/inventory_browser.svelte
@@ -10,12 +10,13 @@
   import InventoryBrowserControls from '#inventory/components/inventory_browser_controls.svelte'
   import { setContext } from 'svelte'
   import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
+  import { getShelvesPromise } from '#shelves/lib/shelves'
 
   export let itemsDataPromise, isMainUser, ownerId, groupId, shelfId
 
   setContext('items-search-filters', { ownerId, groupId, shelfId })
 
-  let itemsIds, textFilterItemsIds
+  let itemsIds, textFilterItemsIds, shelves
 
   const inventoryDisplay = getLocalStorageStore('inventoryDisplay', 'cascade')
 
@@ -55,12 +56,20 @@
 
   let items = [], pagination, componentProps = { isMainUser }
 
+  async function getShelvesData (items, currentShelves) {
+    const shelvesIds = items.map(_.property('shelves')).flat()
+    const newShelvesIds = _.difference(_.uniq(shelvesIds), currentShelves)
+    if (newShelvesIds.length > 0) return getShelvesPromise(newShelvesIds)
+  }
+
   async function setupPagination () {
     items = []
+    shelves = {}
     componentProps.itemsIds = itemsIds
     const remainingItems = clone(itemsIds)
     pagination = {
       items,
+      shelves,
       allowMore: true,
       hasMore: () => {
         return remainingItems.length > 0
@@ -71,6 +80,8 @@
           await app.request('items:getByIds', { ids: batch, items })
         }
         pagination.items = items
+        const newShelves = await getShelvesData(items, shelves)
+        pagination.shelves = _.assign(pagination.shelves, newShelves)
       },
     }
   }

--- a/app/modules/inventory/components/inventory_browser.svelte
+++ b/app/modules/inventory/components/inventory_browser.svelte
@@ -10,7 +10,7 @@
   import InventoryBrowserControls from '#inventory/components/inventory_browser_controls.svelte'
   import { setContext } from 'svelte'
   import { getLocalStorageStore } from '#lib/components/stores/local_storage_stores'
-  import { getShelvesPromise } from '#shelves/lib/shelves'
+  import { getShelves } from '#shelves/lib/shelves'
 
   export let itemsDataPromise, isMainUser, ownerId, groupId, shelfId
 
@@ -59,7 +59,7 @@
   async function getShelvesData (items, currentShelves) {
     const shelvesIds = items.map(_.property('shelves')).flat()
     const newShelvesIds = _.difference(_.uniq(shelvesIds), currentShelves)
-    if (newShelvesIds.length > 0) return getShelvesPromise(newShelvesIds)
+    if (newShelvesIds.length > 0) return getShelves(newShelvesIds)
   }
 
   async function setupPagination () {

--- a/app/modules/inventory/components/item_row.svelte
+++ b/app/modules/inventory/components/item_row.svelte
@@ -1,6 +1,6 @@
 <script>
   import { i18n } from '#user/lib/i18n'
-  import { icon, loadInternalLink } from '#lib/utils'
+  import { icon, isOpenedOutside, loadInternalLink } from '#lib/utils'
   import { imgSrc } from '#lib/handlebars_helpers/images'
   import { transactionsDataFactory } from '#inventory/lib/transactions_data'
   import { getVisibilitySummary, getVisibilitySummaryLabel, visibilitySummariesData } from '#general/lib/visibility'
@@ -39,6 +39,12 @@
 
   function getShelfColor (shelf) {
     return getColorSquareDataUri(shelf.color || getColorHexCodeFromModelId(shelf._id))
+  }
+
+  function onShelfDotClick (e, shelf) {
+    if (isOpenedOutside(e)) return
+    loadShelfLink(shelf)
+    e.preventDefault()
   }
 
   $: {
@@ -104,7 +110,7 @@
           {:else}
             <a
               href="/shelves/{shelf._id}"
-              on:click={() => loadShelfLink(shelf)}
+              on:click={e => onShelfDotClick(e, shelf)}
               title={i18n(shelf.name)}
             >
               <div

--- a/app/modules/inventory/components/item_row.svelte
+++ b/app/modules/inventory/components/item_row.svelte
@@ -1,6 +1,6 @@
 <script>
   import { i18n } from '#user/lib/i18n'
-  import { icon, isOpenedOutside, loadInternalLink } from '#lib/utils'
+  import { icon, loadInternalLink } from '#lib/utils'
   import { imgSrc } from '#lib/handlebars_helpers/images'
   import { transactionsDataFactory } from '#inventory/lib/transactions_data'
   import { getVisibilitySummary, getVisibilitySummaryLabel, visibilitySummariesData } from '#general/lib/visibility'
@@ -8,10 +8,8 @@
   import { serializeItem } from '#inventory/lib/items'
   import { screen } from '#lib/components/stores/screen'
   import ImageDiv from '#components/image_div.svelte'
-  import { getColorSquareDataUri, getColorHexCodeFromModelId } from '#lib/images'
+  import ShelfDot from './shelf_dot.svelte'
   import { isNonEmptyArray } from '#lib/boolean_tests'
-  import screen_ from '#lib/screen'
-  import { loadShelfLink } from '#shelves/components/lib/shelves'
 
   export let item, showUser, shelves
 
@@ -36,16 +34,6 @@
     inventoryPathname,
     shelvesIds,
     itemShelves
-
-  function getShelfColor (shelf) {
-    return getColorSquareDataUri(shelf.color || getColorHexCodeFromModelId(shelf._id))
-  }
-
-  function onShelfDotClick (e, shelf) {
-    if (isOpenedOutside(e)) return
-    loadShelfLink(shelf)
-    e.preventDefault()
-  }
 
   $: {
     ;({ details = '', transaction, visibility, shelves: shelvesIds } = $itemStore)
@@ -99,28 +87,7 @@
   {#if isNonEmptyArray(itemShelves)}
     <ul class="shelves-dots">
       {#each itemShelves as shelf}
-        <li>
-          {#if screen_.isSmall(600)}
-            <div
-              class="shelf-dot"
-              style="background-image: url({imgSrc(getShelfColor(shelf), 8)})"
-              title={i18n(shelf.name)}
-            >
-            </div>
-          {:else}
-            <a
-              href="/shelves/{shelf._id}"
-              on:click={e => onShelfDotClick(e, shelf)}
-              title={i18n(shelf.name)}
-            >
-              <div
-                class="shelf-dot"
-                style="background-image: url({imgSrc(getShelfColor(shelf), 8)})"
-              >
-              </div>
-            </a>
-          {/if}
-        </li>
+        <ShelfDot {shelf} />
       {/each}
     </ul>
   {/if}
@@ -185,11 +152,6 @@
   .shelves-dots{
     @include display-flex(row);
     margin: 0 0.4em;
-  }
-  .shelf-dot{
-    @include radius;
-    width: 1em;
-    height: 1em;
   }
   .transaction, .visibility, .avatar{
     @include radius;
@@ -271,9 +233,6 @@
       @include display-flex(column, flex-end, center, wrap-reverse);
       height: 4.5em;
     }
-    .shelf-dot{
-      margin: 0.3em;
-    }
     .modes{
       margin-right: 0.2em;
       flex-direction: column-reverse;
@@ -312,9 +271,6 @@
       max-height: 3em;
       margin: 0 0.5em;
       flex: 1 1 auto;
-    }
-    .shelf-dot{
-      margin: 0.2em;
     }
     .transaction, .visibility, .user{
       margin-right: 0.5em;

--- a/app/modules/inventory/components/items_table.svelte
+++ b/app/modules/inventory/components/items_table.svelte
@@ -5,7 +5,7 @@
   import ItemsTableSelectionEditor from '#inventory/components/items_table_selection_editor.svelte'
   import Spinner from '#components/spinner.svelte'
 
-  export let items, isMainUser, itemsIds, waiting, haveSeveralOwners
+  export let items, shelves, isMainUser, itemsIds, waiting, haveSeveralOwners
 
   let selectedItemsIds = []
 
@@ -25,13 +25,12 @@
 
   $: emptySelection = selectedItemsIds.length === 0
 </script>
-
 <div class="items-table">
   {#if isMainUser}
     <ul id="selectable-items">
       {#each items as item (item._id)}
         <li>
-          <ItemRow bind:item>
+          <ItemRow bind:item {shelves}>
             <input
               slot="checkbox"
               type="checkbox"
@@ -45,7 +44,7 @@
   {:else}
     <ul>
       {#each items as item (item._id)}
-        <li><ItemRow {item} showUser={haveSeveralOwners} /></li>
+        <li><ItemRow {item} {shelves} showUser={haveSeveralOwners} /></li>
       {/each}
     </ul>
   {/if}

--- a/app/modules/inventory/components/paginated_items.svelte
+++ b/app/modules/inventory/components/paginated_items.svelte
@@ -8,7 +8,8 @@
 
   export let Component, componentProps, pagination, haveSeveralOwners = false
 
-  let items = [], flash, waiting
+  let items = [], shelves = []
+  let flash, waiting
   let fetchMore, hasMore, allowMore
 
   let fetching = false
@@ -19,6 +20,7 @@
       .then(() => {
         assert_.array(pagination.items)
         items = pagination.items
+        shelves = pagination.shelves
       })
       .catch(err => flash = err)
       .finally(() => fetching = false)
@@ -57,6 +59,7 @@
     <svelte:component
       this={Component}
       {items}
+      {shelves}
       {waiting}
       {haveSeveralOwners}
       {...componentProps} />

--- a/app/modules/inventory/components/shelf_dot.svelte
+++ b/app/modules/inventory/components/shelf_dot.svelte
@@ -1,0 +1,55 @@
+<script>
+  import { isOpenedOutside } from '#lib/utils'
+  import { loadShelfLink } from '#shelves/components/lib/shelves'
+  import { getColorHexCodeFromModelId } from '#lib/images'
+  import screen_ from '#lib/screen'
+
+  export let shelf
+
+  const { name, _id } = shelf
+
+  const colorHexCode = shelf.color || `#${getColorHexCodeFromModelId(_id)}`
+
+  function onShelfDotClick (e, shelf) {
+    if (isOpenedOutside(e)) return
+    loadShelfLink(shelf)
+    e.preventDefault()
+  }
+</script>
+<li>
+  {#if screen_.isSmall(600)}
+    <div
+      class="shelf-dot"
+      title={name}
+      style:background-color={colorHexCode}
+    />
+  {:else}
+    <a
+      href="/shelves/{_id}"
+      on:click={e => onShelfDotClick(e, shelf)}
+      title={name}
+    >
+      <div
+        class="shelf-dot"
+        style:background-color={colorHexCode}
+      />
+    </a>
+  {/if}
+</li>
+<style lang="scss">
+  @import "#general/scss/utils";
+
+  .shelf-dot{
+    @include radius;
+    width: 1em;
+    height: 1em;
+    margin: 0.3em;
+  }
+
+  /* Large screens */
+  @media screen and (min-width: $smaller-screen){
+    .shelf-dot{
+      margin: 0.2em;
+    }
+  }
+</style>

--- a/app/modules/inventory/components/shelf_dot.svelte
+++ b/app/modules/inventory/components/shelf_dot.svelte
@@ -10,7 +10,7 @@
 
   const colorHexCode = shelf.color || `#${getColorHexCodeFromModelId(_id)}`
 
-  function onShelfDotClick (e, shelf) {
+  function onShelfDotClick (e) {
     if (isOpenedOutside(e)) return
     loadShelfLink(shelf)
     e.preventDefault()
@@ -26,7 +26,7 @@
   {:else}
     <a
       href="/shelves/{_id}"
-      on:click={e => onShelfDotClick(e, shelf)}
+      on:click={onShelfDotClick}
       title={name}
     >
       <div

--- a/app/modules/inventory/components/shelf_info.svelte
+++ b/app/modules/inventory/components/shelf_info.svelte
@@ -7,7 +7,11 @@
 </script>
 
 <div class="shelf-info">
-  <img class="shelf-picture" src={imgSrc(shelfColor)} alt={shelf.name} />
+  <img
+    class="shelf-picture"
+    src={imgSrc(shelfColor)}
+    alt={shelf.name}
+  />
   <div class="shelf-text">
     <p class="name">{shelf.name}</p>
     <p class="description">{shelf.description}</p>

--- a/app/modules/shelves/components/lib/shelves.js
+++ b/app/modules/shelves/components/lib/shelves.js
@@ -1,5 +1,6 @@
 import { i18n } from '#user/lib/i18n'
 import { serializeShelf } from '#shelves/lib/shelves'
+import ShelfModel from '#shelves/models/shelf'
 
 export const serializeShelfData = (shelf, withoutShelf) => {
   let name, description, pathname, title, picture, iconData, iconLabel, isEditable
@@ -15,4 +16,9 @@ export const serializeShelfData = (shelf, withoutShelf) => {
   }
 
   return { name, description, pathname, title, picture, iconData, iconLabel, isEditable }
+}
+
+export function loadShelfLink (shelf) {
+  const model = new ShelfModel(shelf)
+  app.vent.trigger('inventory:select', 'shelf', model)
 }

--- a/app/modules/shelves/components/shelf_li.svelte
+++ b/app/modules/shelves/components/shelf_li.svelte
@@ -2,8 +2,7 @@
   import { i18n } from '#user/lib/i18n'
   import { icon, isOpenedOutside } from '#lib/utils'
   import { imgSrc } from '#lib/handlebars_helpers/images'
-  import { serializeShelfData } from './lib/shelves'
-  import Shelf from '#shelves/models/shelf'
+  import { serializeShelfData, loadShelfLink } from './lib/shelves'
 
   export let shelf, withoutShelf
 
@@ -14,8 +13,7 @@
     if (withoutShelf) {
       app.vent.trigger('inventory:select', 'without-shelf')
     } else {
-      const model = new Shelf(shelf)
-      app.vent.trigger('inventory:select', 'shelf', model)
+      loadShelfLink(shelf)
     }
     e.preventDefault()
   }

--- a/app/modules/shelves/lib/shelves.js
+++ b/app/modules/shelves/lib/shelves.js
@@ -102,7 +102,7 @@ export function serializeShelf (shelf) {
   return shelf
 }
 
-export async function getShelvesPromise (shelvesIds, mainUserIsOwner) {
+export async function getShelves (shelvesIds, mainUserIsOwner) {
   if (mainUserIsOwner) {
     const { shelves } = await preq.get(app.API.shelves.byOwners(app.user.id))
     return shelves

--- a/app/modules/shelves/lib/shelves.js
+++ b/app/modules/shelves/lib/shelves.js
@@ -101,3 +101,12 @@ export function serializeShelf (shelf) {
   }
   return shelf
 }
+
+export async function getShelvesPromise (shelvesIds, mainUserIsOwner) {
+  if (mainUserIsOwner) {
+    const { shelves } = await preq.get(app.API.shelves.byOwners(app.user.id))
+    return shelves
+  } else {
+    return getByIds(shelvesIds)
+  }
+}


### PR DESCRIPTION
assumptions for PR review: most items belong to only one shelf

small screen view is a test, maybe it can just be removed completely on very small screen (as it could be too much info)

or it could be removed for group inv browser and shelf inv browser (so, leaving it only for user inv browser). No strong opinion

![2022-11-20_14-25](https://user-images.githubusercontent.com/5363918/202904596-43d9ada1-226a-4e06-a16d-7bd23c36aca5.png)

I would not find an elegant way to display those dots in casacade view. So i propose to leave it this way for now
