### PR TITLE
Ignore compat

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,13 +15,6 @@ module.exports = {
   extends: [
     // See https://github.com/standard/eslint-config-standard/blob/master/eslintrc.json
     'standard',
-    // Helps to spot unsupported features that woul result in
-    // babel including the corresponding core-js polyfills
-    // in the bundle served to all users
-    // See https://github.com/amilajack/eslint-plugin-compat
-    // NB: some unsupported features are unfortunately not detected
-    // Ex: Array methods https://github.com/amilajack/eslint-plugin-compat/issues/258
-    'plugin:compat/recommended',
     'plugin:svelte/recommended',
   ],
   rules: {
@@ -139,10 +132,4 @@ module.exports = {
       }
     }
   ],
-  settings: {
-    // Used by eslint-plugin-compat
-    polyfills: [
-      'Promise',
-    ],
-  },
 }

--- a/.eslintrc.pre-commit.cjs
+++ b/.eslintrc.pre-commit.cjs
@@ -1,0 +1,20 @@
+// This config file is used by pre-commit hooks
+// See package.json script lint-pre-commit
+
+module.exports = {
+  extends: [
+    // Helps to spot unsupported features that woul result in
+    // babel including the corresponding core-js polyfills
+    // in the bundle served to all users
+    // See https://github.com/amilajack/eslint-plugin-compat
+    // NB: some unsupported features are unfortunately not detected
+    // Ex: Array methods https://github.com/amilajack/eslint-plugin-compat/issues/258
+    'plugin:compat/recommended',
+  ],
+  settings: {
+    // Used by eslint-plugin-compat
+    polyfills: [
+      'Promise',
+    ],
+  },
+}

--- a/app/lib/components/actions/viewport.js
+++ b/app/lib/components/actions/viewport.js
@@ -6,12 +6,6 @@ let intersectionObserver
 function ensureIntersectionObserverExists () {
   if (intersectionObserver) return
 
-  // This will not work on "UC Browser for Android" (a.k.a. and_uc) 12.12
-  // as "isIntersecting property of IntersectionObserverEntry was not implemented"
-  // See https://caniuse.com/intersectionobserver
-  // Core-js does not offer a polyfill for it
-  // See https://github.com/zloirock/core-js/issues/386
-  // eslint-disable-next-line compat/compat
   intersectionObserver = new IntersectionObserver(entries => {
     entries.forEach(entry => {
       const eventName = entry.isIntersecting ? 'enterViewport' : 'leaveViewport'

--- a/scripts/lint_staged
+++ b/scripts/lint_staged
@@ -11,6 +11,6 @@ else
   if [ "$1" = "fix"  ] || [ "$1" = "--fix" ]; then
     echo $staged | xargs npm run lint-fix
   else
-    echo $staged | xargs npm run lint
+    echo $staged | xargs npm run lint -- --config .eslintrc.pre-commit.cjs
   fi
 fi


### PR DESCRIPTION
This is an attempt to not extend `compat` plugin, introduced by 170620efd, for a quicker linting (ie. in editor).

This is because, when benchmarking eslint (prepend `TIMING=1` to the command), the process ends up showing that the `compat` plugin takes a while, maybe it could be disabled in development?

Example on a quite big file:

```
$ TIMING=1 eslint app/modules/entities/components/layouts/works_browser.svelte
Rule                                 | Time (ms) | Relative
:------------------------------------|----------:|--------:
svelte/valid-compile                 |   267.794 |    46.8%
compat/compat                        |   196.162 |    34.3%
indent                               |    31.995 |     5.6%
svelte/indent                        |    16.262 |     2.8%
...
```

Unfortunetely, eslint is complainging that a code comment in `viewport.js` wants this plugin. I havent found a workaround for it, hence the WIP status of the PR