### PR TITLE
Move loading message within selector's dropdown

### DIFF
--- a/app/modules/entities/components/layouts/author.svelte
+++ b/app/modules/entities/components/layouts/author.svelte
@@ -72,31 +72,30 @@
         {/await}
       </div>
     </div>
-    <MissingEntitiesMenu
-      waiting={waitingForSubEntities}
-      questionText="A series or a work by this author is missing in the common database?"
-      {createButtons}
-    />
-    <div class="relatives-lists">
-      <RelativeEntitiesList
-        {entity}
-        claims={entity.claims['wdt:P737']}
-        label={i18n('authors_or_works_influencing_author', { name: entity.label })}
+    <!-- waiting for subentities to not display relative entities list before work browser -->
+    <!-- to not having to push them down while work broser is being displayed -->
+    {#await waitingForSubEntities}
+      <MissingEntitiesMenu
+        waiting={waitingForSubEntities}
+        questionText="A series or a work by this author is missing in the common database?"
+        {createButtons}
       />
-      <RelativeEntitiesList
-        {entity}
-        property={[ 'wdt:P2679', 'wdt:P2680' ]}
-        label={i18n('editions_prefaced_or_postfaced_by_author', { name: entity.label })}
-      />
-      {#each getRelativeEntitiesProperties(type) as property}
+      <div class="relatives-lists">
         <RelativeEntitiesList
           {entity}
-          {property}
-          label={getRelativeEntitiesListLabel({ property, entity })}
+          property={[ 'wdt:P2679', 'wdt:P2680' ]}
+          label={i18n('editions_prefaced_or_postfaced_by_author', { name: entity.label })}
         />
-      {/each}
-    </div>
-    <HomonymDeduplicates {entity} />
+        {#each getRelativeEntitiesProperties(type) as property}
+          <RelativeEntitiesList
+            {entity}
+            {property}
+            label={getRelativeEntitiesListLabel({ property, entity })}
+          />
+        {/each}
+      </div>
+      <HomonymDeduplicates {entity} />
+    {/await}
   </div>
 </BaseLayout>
 

--- a/app/modules/entities/components/layouts/works_browser.svelte
+++ b/app/modules/entities/components/layouts/works_browser.svelte
@@ -32,38 +32,43 @@
 </script>
 <Flash state={flash} />
 <div class="works-browser">
-  <div class="wrapper" class:unwrapped={showControls}>
-    {#if $screen.isSmallerThan(smallScreenThreshold) && isNotEmpty}
-      <button
-        class="toggle-controls"
-        on:click={() => wrapped = !wrapped}
-        aria-controls="works-browser-controls"
-      >
-        {#if showControls}
-          {@html icon('caret-up')}
-        {:else}
-          {@html icon('cog')}
-          {i18n('Advanced options')}
-          {@html icon('caret-down')}
-        {/if}
-      </button>
-    {/if}
-    {#if showControls}
-      {#if isNonEmptyArray(allWorks)}
-        <div class="controls">
-          <WorksBrowserFacets
-            works={allWorks}
-            bind:facets
-            bind:facetsSelectors
-            bind:facetsSelectedValues
-            bind:flash
-          />
-          <WorksBrowserTextFilter bind:textFilterUris />
-          <SelectDropdown bind:value={displayMode} options={displayOptions} buttonLabel={I18n('display_mode')} />
-        </div>
+  {#if isNotEmpty}
+    <div
+      class="wrapper"
+      class:unwrapped={showControls}
+    >
+      {#if $screen.isSmallerThan(smallScreenThreshold) && isNotEmpty}
+        <button
+          class="toggle-controls"
+          on:click={() => wrapped = !wrapped}
+          aria-controls="works-browser-controls"
+        >
+          {#if showControls}
+            {@html icon('caret-up')}
+          {:else}
+            {@html icon('cog')}
+            {i18n('Advanced options')}
+            {@html icon('caret-down')}
+          {/if}
+        </button>
       {/if}
-    {/if}
-  </div>
+      {#if showControls}
+        {#if isNonEmptyArray(allWorks)}
+          <div class="controls">
+            <WorksBrowserFacets
+              works={allWorks}
+              bind:facets
+              bind:facetsSelectors
+              bind:facetsSelectedValues
+              bind:flash
+            />
+            <WorksBrowserTextFilter bind:textFilterUris />
+            <SelectDropdown bind:value={displayMode} options={displayOptions} buttonLabel={I18n('display_mode')} />
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/if}
 
   {#if sections}
     {#each sections as section}

--- a/app/modules/entities/components/layouts/works_browser.svelte
+++ b/app/modules/entities/components/layouts/works_browser.svelte
@@ -146,13 +146,24 @@
     }
   }
 
-  /* Very small screens */
-  @media screen and (max-width: $very-small-screen){
-    .wrapper:not(.unwrapped){
-      @include display-flex(column, center, stretch);
+  /* Smaller screens */
+  @media screen and (max-width: 450px){
+    .controls{
+      :global(.select-dropdown), :global(.dropdown-content), :global(.works-browser-text-filter){
+        margin: 0.5em;
+        width: 100%;
+      }
     }
     .wrapper{
+      &:not(.unwrapped){
+        @include display-flex(column, center, stretch);
+      }
       @include display-flex(column, center, space-between);
+      &.unwrapped{
+        .toggle-controls{
+          align-self: stretch;
+        }
+      }
     }
   }
 </style>

--- a/app/modules/entities/components/layouts/works_browser.svelte
+++ b/app/modules/entities/components/layouts/works_browser.svelte
@@ -39,11 +39,11 @@
         on:click={() => wrapped = !wrapped}
         aria-controls="works-browser-controls"
       >
-        {@html icon('cog')}
-        {i18n('Advanced options')}
         {#if showControls}
           {@html icon('caret-up')}
         {:else}
+          {@html icon('cog')}
+          {i18n('Advanced options')}
           {@html icon('caret-down')}
         {/if}
       </button>
@@ -84,7 +84,8 @@
     margin-block-end: 0.5em;
     @include radius;
     padding: 0.5em;
-    @include display-flex(row, center, flex-start);
+    @include display-flex(row, space-between);
+    flex: 1;
     :global(.select-dropdown), :global(.dropdown-content){
       inline-size: 10em;
     }
@@ -94,15 +95,15 @@
   }
 
   .wrapper{
-    @include display-flex(column, stretch);
-    margin-block: 0.5em 1em;
+    @include display-flex(row-reverse, space-between);
+    margin-block-start: 0.5em;
     &:not(.unwrapped){
       @include display-flex(column, flex-end);
     }
     &.unwrapped{
       background-color: $off-white;
       .toggle-controls{
-        align-self: flex-end;
+        align-self: flex-start;
       }
     }
   }
@@ -148,7 +149,10 @@
   /* Very small screens */
   @media screen and (max-width: $very-small-screen){
     .wrapper:not(.unwrapped){
-      @include display-flex(column, center);
+      @include display-flex(column, center, stretch);
+    }
+    .wrapper{
+      @include display-flex(column, center, space-between);
     }
   }
 </style>

--- a/app/modules/entities/components/layouts/works_browser.svelte
+++ b/app/modules/entities/components/layouts/works_browser.svelte
@@ -37,21 +37,6 @@
       class="wrapper"
       class:unwrapped={showControls}
     >
-      {#if $screen.isSmallerThan(smallScreenThreshold) && isNotEmpty}
-        <button
-          class="toggle-controls"
-          on:click={() => wrapped = !wrapped}
-          aria-controls="works-browser-controls"
-        >
-          {#if showControls}
-            {@html icon('caret-up')}
-          {:else}
-            {@html icon('cog')}
-            {i18n('Advanced options')}
-            {@html icon('caret-down')}
-          {/if}
-        </button>
-      {/if}
       {#if showControls}
         {#if isNonEmptyArray(allWorks)}
           <div class="controls">
@@ -66,6 +51,21 @@
             <SelectDropdown bind:value={displayMode} options={displayOptions} buttonLabel={I18n('display_mode')} />
           </div>
         {/if}
+      {/if}
+      {#if $screen.isSmallerThan(smallScreenThreshold) && isNotEmpty}
+        <button
+          class="toggle-controls"
+          on:click={() => wrapped = !wrapped}
+          aria-controls="works-browser-controls"
+        >
+          {#if showControls}
+            {@html icon('caret-up')}
+          {:else}
+            {@html icon('cog')}
+            {i18n('Advanced options')}
+            {@html icon('caret-down')}
+          {/if}
+        </button>
       {/if}
     </div>
   {/if}
@@ -100,7 +100,7 @@
   }
 
   .wrapper{
-    @include display-flex(row-reverse, space-between);
+    @include display-flex(row, space-between);
     margin-block-start: 0.5em;
     &:not(.unwrapped){
       @include display-flex(column, flex-end);

--- a/app/modules/entities/components/layouts/works_browser_facets.svelte
+++ b/app/modules/entities/components/layouts/works_browser_facets.svelte
@@ -10,8 +10,8 @@
   const facetsObj = getWorksFacets({ works, context: layoutContext })
 
   let loadingMessage
-  const urisSize = facetsObj.valuesUris.length
-  loadingMessage = I18n('loading_facets_may_take_a_while', { smart_count: urisSize })
+  const urisCount = facetsObj.valuesUris.length
+  loadingMessage = I18n('loading_facets_may_take_a_while', { smart_count: urisCount })
 
   ;({ facets, facetsSelectedValues } = facetsObj)
   const waitingForOptions = getFacetsEntitiesBasicInfo(facetsObj)

--- a/app/modules/entities/components/layouts/works_browser_facets.svelte
+++ b/app/modules/entities/components/layouts/works_browser_facets.svelte
@@ -1,31 +1,39 @@
 <script>
   import SelectDropdown from '#components/select_dropdown.svelte'
-  import { i18n } from '#user/lib/i18n'
-  import { entityProperties, getWorksFacets } from '#entities/components/lib/works_browser_helpers'
-  import Spinner from '#components/spinner.svelte'
+  import { entityProperties, getWorksFacets, getFacetsSelectors } from '#entities/components/lib/works_browser_helpers'
   import { getContext } from 'svelte'
+  import { i18n, I18n } from '#user/lib/i18n'
 
   export let works, facets, facetsSelectors, facetsSelectedValues, flash
 
   const layoutContext = getContext('layout-context')
+  const facetsObj = getWorksFacets({ works, context: layoutContext })
 
-  const waitForFacets = getWorksFacets({ works, context: layoutContext })
-    .then(res => ({ facets, facetsSelectedValues, facetsSelectors } = res))
-    .catch(err => flash = err)
+  let loadingMessage
+  const displayLoadingInfoMessage = async facetsObj => {
+    const urisSize = facetsObj.valuesUris.length
+    loadingMessage = I18n('loading_may_take_a_while', { smart_count: urisSize })
+  }
+
+  ({ facets, facetsSelectedValues } = facetsObj)
+  Promise.all([
+    getFacetsSelectors(facetsObj),
+    displayLoadingInfoMessage(facetsObj)
+  ])
+  .then(res => ({ facets, facetsSelectedValues, facetsSelectors } = res[0]))
+  .catch(err => flash = err)
+  .finally(() => loadingMessage = false)
 </script>
-
-{#await waitForFacets}
-  <Spinner />
-{:then}
-  {#each Object.keys(facets) as property}
-    {#if !facetsSelectors[property].disabled}
-      <SelectDropdown
-        bind:value={facetsSelectedValues[property]}
-        options={facetsSelectors[property].options}
-        resetValue="all"
-        buttonLabel={i18n(property)}
-        withImage={entityProperties.includes(property)}
-      />
-    {/if}
-  {/each}
-{/await}
+{#each Object.keys(facets) as property}
+  <SelectDropdown
+    bind:value={facetsSelectedValues[property]}
+    options={facetsSelectors?.[property].options}
+    resetValue='all'
+    {loadingMessage}
+    buttonLabel={i18n(property)}
+    withImage={entityProperties.includes(property)}
+  />
+{/each}
+<style lang="scss">
+  @import '#general/scss/utils';
+</style>

--- a/app/modules/entities/components/layouts/works_browser_facets.svelte
+++ b/app/modules/entities/components/layouts/works_browser_facets.svelte
@@ -1,6 +1,6 @@
 <script>
   import SelectDropdown from '#components/select_dropdown.svelte'
-  import { entityProperties, getWorksFacets, getFacetsSelectors } from '#entities/components/lib/works_browser_helpers'
+  import { entityProperties, getWorksFacets, getFacetsEntitiesBasicInfo } from '#entities/components/lib/works_browser_helpers'
   import { getContext } from 'svelte'
   import { i18n, I18n } from '#user/lib/i18n'
 
@@ -10,25 +10,20 @@
   const facetsObj = getWorksFacets({ works, context: layoutContext })
 
   let loadingMessage
-  const displayLoadingInfoMessage = async facetsObj => {
-    const urisSize = facetsObj.valuesUris.length
-    loadingMessage = I18n('loading_may_take_a_while', { smart_count: urisSize })
-  }
+  const urisSize = facetsObj.valuesUris.length
+  loadingMessage = I18n('loading_facets_may_take_a_while', { smart_count: urisSize })
 
-  ({ facets, facetsSelectedValues } = facetsObj)
-  Promise.all([
-    getFacetsSelectors(facetsObj),
-    displayLoadingInfoMessage(facetsObj)
-  ])
-  .then(res => ({ facets, facetsSelectedValues, facetsSelectors } = res[0]))
-  .catch(err => flash = err)
-  .finally(() => loadingMessage = false)
+  ;({ facets, facetsSelectedValues } = facetsObj)
+  const waitingForOptions = getFacetsEntitiesBasicInfo(facetsObj)
+    .then(res => ({ facets, facetsSelectedValues, facetsSelectors } = res))
+    .catch(err => flash = err)
 </script>
 {#each Object.keys(facets) as property}
   <SelectDropdown
     bind:value={facetsSelectedValues[property]}
     options={facetsSelectors?.[property].options}
-    resetValue='all'
+    resetValue="all"
+    {waitingForOptions}
     {loadingMessage}
     buttonLabel={i18n(property)}
     withImage={entityProperties.includes(property)}

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -7,18 +7,21 @@ export function isSubEntitiesType (type) {
   return [ 'serie', 'collection' ].includes(type)
 }
 
-export async function getWorksFacets ({ works, context }) {
+export function getWorksFacets ({ works, context }) {
   const contextProperties = facetsProperties[context]
   const { facets, facetsSelectedValues } = initialize({ contextProperties })
 
   const valuesUris = []
   works.forEach(setWorkFacets({ facets, valuesUris, contextProperties }))
+  removeFacetsWithNoKnownValue(facets)
+  return { valuesUris, facets, facetsSelectedValues }
+}
 
+export async function getFacetsSelectors (facetsObj) {
+  const { valuesUris, facets } = facetsObj
   const facetsEntitiesBasicInfo = await getBasicInfo(valuesUris)
-
   const facetsSelectors = getSelectorsOptions({ facets, facetsEntitiesBasicInfo })
-
-  return { facets, facetsEntitiesBasicInfo, facetsSelectedValues, facetsSelectors }
+  return { ...facetsObj, facetsEntitiesBasicInfo, facetsSelectors }
 }
 
 const initialize = ({ contextProperties }) => {
@@ -53,6 +56,15 @@ const setWorkFacets = ({ facets, valuesUris, contextProperties }) => work => {
   }
 }
 
+const removeFacetsWithNoKnownValue = facets => {
+  Object.keys(facets).forEach(prop => {
+    const facet = facets[prop]
+    if (notOnlyUnknownKey(facet)) delete facets[prop]
+  })
+}
+
+const notOnlyUnknownKey = facet => facet.unknown && Object.keys(facet).length === 1
+
 const getSelectorsOptions = ({ facets, facetsEntitiesBasicInfo }) => {
   const facetsSelectors = {}
   for (const [ property, worksUrisPerValue ] of Object.entries(facets)) {
@@ -62,7 +74,6 @@ const getSelectorsOptions = ({ facets, facetsEntitiesBasicInfo }) => {
         ...getOptions({ property, worksUrisPerValue, facetsEntitiesBasicInfo })
       ]
     }
-    facetSelector.disabled = hasNoKnownValue(facetSelector.options)
     facetsSelectors[property] = facetSelector
   }
   return facetsSelectors
@@ -73,10 +84,6 @@ const getOptions = ({ property, worksUrisPerValue, facetsEntitiesBasicInfo }) =>
   return Object.keys(worksUrisPerValue)
   .map(formatOption({ property, worksUrisPerValue, facetsEntitiesBasicInfo }))
   .sort(sortFn)
-}
-
-const hasNoKnownValue = options => {
-  return !options.some(option => option.value !== 'all' && option.value !== 'unknown')
 }
 
 async function getBasicInfo (uris) {

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -57,10 +57,9 @@ const setWorkFacets = ({ facets, valuesUris, contextProperties }) => work => {
 }
 
 const removeFacetsWithNoKnownValue = facets => {
-  Object.keys(facets).forEach(prop => {
-    const facet = facets[prop]
+  for (const [ prop, facet ] of Object.entries(facets)) {
     if (notOnlyUnknownKey(facet)) delete facets[prop]
-  })
+  }
 }
 
 const notOnlyUnknownKey = facet => facet.unknown && Object.keys(facet).length === 1

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -17,7 +17,7 @@ export function getWorksFacets ({ works, context }) {
   return { valuesUris, facets, facetsSelectedValues }
 }
 
-export async function getFacetsSelectors (facetsObj) {
+export async function getFacetsEntitiesBasicInfo (facetsObj) {
   const { valuesUris, facets } = facetsObj
   const facetsEntitiesBasicInfo = await getBasicInfo(valuesUris)
   const facetsSelectors = getSelectorsOptions({ facets, facetsEntitiesBasicInfo })

--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -15,7 +15,8 @@
     buttonLabel = null,
     withImage = false,
     hideCurrentlySelectedOption = false,
-    loadingMessage = false
+    loadingMessage,
+    waitingForOptions
   const buttonId = uniqueId('button')
 
   function onKeyDown (e) {
@@ -63,12 +64,12 @@
       {/if}
     </div>
     <div slot="dropdown-content" role="presentation">
-      {#if loadingMessage}
+      {#await waitingForOptions}
         <div class="loading-message">
           <Spinner />
           <p>{loadingMessage}</p>
         </div>
-      {:else}
+      {:then}
         {#each options as option}
           {#if !(hideCurrentlySelectedOption && option.value === value)}
             <button
@@ -81,7 +82,7 @@
             </button>
           {/if}
         {/each}
-      {/if}
+      {/await}
     </div>
   </Dropdown>
 </div>

--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -1,6 +1,7 @@
 <!-- This component mimicks a <select>
      See https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_build_custom_form_controls -->
 <script>
+  import Spinner from '#general/components/spinner.svelte'
   import Dropdown from '#components/dropdown.svelte'
   import SelectDropdownOption from '#components/select_dropdown_option.svelte'
   import { getActionKey } from '#lib/key_events'
@@ -8,7 +9,13 @@
   import { I18n } from '#user/lib/i18n'
   import { uniqueId } from 'underscore'
 
-  export let value, resetValue = null, options, buttonLabel = null, withImage = false, hideCurrentlySelectedOption = false
+  export let value,
+    resetValue = null,
+    options,
+    buttonLabel = null,
+    withImage = false,
+    hideCurrentlySelectedOption = false,
+    loadingMessage = false
   const buttonId = uniqueId('button')
 
   function onKeyDown (e) {
@@ -20,7 +27,8 @@
     e.preventDefault()
   }
 
-  $: currentOption = options.find(option => option.value === value)
+  const optionPlaceholder = { value: 'all', text: I18n('all') }
+  $: currentOption = options?.find(option => option.value === value) || optionPlaceholder
 
   function selectNext (indexIncrement) {
     const currentOptionIndex = options.indexOf(currentOption)
@@ -55,22 +63,35 @@
       {/if}
     </div>
     <div slot="dropdown-content" role="presentation">
-      {#each options as option}
-        {#if !(hideCurrentlySelectedOption && option.value === value)}
-          <button
-            role="option"
-            title={option.text}
-            aria-selected={option.value === value}
-            on:click={() => value = option.value}
-          >
-            <SelectDropdownOption {option} {withImage} />
-          </button>
-        {/if}
-      {/each}
+      {#if loadingMessage}
+        <div class="loading-message">
+          <Spinner />
+          <p>{loadingMessage}</p>
+        </div>
+      {:else}
+        {#each options as option}
+          {#if !(hideCurrentlySelectedOption && option.value === value)}
+            <button
+              role="option"
+              title={option.text}
+              aria-selected={option.value === value}
+              on:click={() => value = option.value}
+            >
+              <SelectDropdownOption {option} {withImage} />
+            </button>
+          {/if}
+        {/each}
+      {/if}
     </div>
   </Dropdown>
 </div>
 
 <style lang="scss">
   @import "#general/scss/select_dropdown_commons";
+  .loading-message{
+    margin: 1em 0;
+    padding: 0 1em;
+    text-align: center;
+    white-space: break-spaces;
+  }
 </style>


### PR DESCRIPTION
Since it can take some time to load facets, and information on what to select can be displayed as soon as advanced option is clicked on.

To do this, we extracted the sync part out of `getWorksFacets`, and allow selector to have a default value placeholder

A friendly message is displayed within the selector (reviewer: don't be lured by the absence of i18n key, CSS should be correct when key exists)

This is preparing ground for adding large reverse claims values to get filtered (ie. wdt:P69 educated at, or wdt:P166 award received)