### PR TITLE
Sort by popularity

### DIFF
--- a/app/api/entities.js
+++ b/app/api/entities.js
@@ -48,6 +48,11 @@ export default {
   changes: action('changes'),
   history: id => action('history', { id }),
 
+  popularity (uris, refresh) {
+    uris = forceArray(uris).join('|')
+    return action('popularity', { uris, refresh })
+  },
+
   // POST
   create: action('create'),
   resolve: action('resolve'),

--- a/app/modules/entities/components/layouts/editions_list.svelte
+++ b/app/modules/entities/components/layouts/editions_list.svelte
@@ -11,6 +11,7 @@
     publishersByUris,
     parentEntity,
     initialEditions,
+    waitingForItems,
     itemsByEditions
 </script>
 <div class="editions-section">
@@ -33,6 +34,7 @@
         bind:editions
         {initialEditions}
         {someEditions}
+        {waitingForItems}
       />
     {/if}
     <EntitiesList

--- a/app/modules/entities/components/layouts/editions_list_actions.svelte
+++ b/app/modules/entities/components/layouts/editions_list_actions.svelte
@@ -7,6 +7,7 @@
   import { onChange } from '#lib/svelte/svelte'
   import { icon } from '#lib/utils'
   import { getContext } from 'svelte'
+  import SortEntitiesBy from '#entities/components/layouts/sort_entities_by.svelte'
 
   export let editions, initialEditions
 
@@ -77,7 +78,7 @@
   $: onChange(initialEditions, $filters, refreshFilters)
 </script>
 
-<div class="filters">
+<div class="filters menu">
   <span class="filters-header">{i18n('Filter by')}</span>
 
   {#await waitingForLangEntities}
@@ -164,10 +165,30 @@
     {/if}
   </div>
 </div>
+<div class="sort-selector-wrapper menu">
+  <SortEntitiesBy
+    sortingType="editions"
+    bind:entities={editions}
+  />
+</div>
 <Flash state={flash} />
 
 <style lang="scss">
   @import "#general/scss/utils";
+  .sort-selector-wrapper{
+    width: 100%;
+    margin-top: 0.5em;
+    :global(.sort-selector), :global(label){
+      margin: 0 1em;
+      margin-left: 0;
+      font-size: 100%;
+      text-align: left;
+    }
+  }
+  .menu{
+    background-color: $light-grey;
+    padding: 0.5em;
+  }
   .filters{
     align-self: stretch;
   }

--- a/app/modules/entities/components/layouts/editions_list_actions.svelte
+++ b/app/modules/entities/components/layouts/editions_list_actions.svelte
@@ -9,7 +9,7 @@
   import { getContext } from 'svelte'
   import SortEntitiesBy from '#entities/components/layouts/sort_entities_by.svelte'
 
-  export let editions, initialEditions
+  export let editions, initialEditions, waitingForItems
 
   const filters = getContext('work-layout:filters-store')
 
@@ -169,6 +169,7 @@
   <SortEntitiesBy
     sortingType="editions"
     bind:entities={editions}
+    {waitingForItems}
   />
 </div>
 <Flash state={flash} />

--- a/app/modules/entities/components/layouts/editions_list_actions.svelte
+++ b/app/modules/entities/components/layouts/editions_list_actions.svelte
@@ -167,7 +167,7 @@
 </div>
 <div class="sort-selector-wrapper menu">
   <SortEntitiesBy
-    sortingType="editions"
+    sortingType="edition"
     bind:entities={editions}
     {waitingForItems}
   />
@@ -178,12 +178,12 @@
   @import "#general/scss/utils";
   .sort-selector-wrapper{
     width: 100%;
-    margin-top: 0.5em;
+    margin-block-start: 0.5em;
     :global(.sort-selector), :global(label){
       margin: 0 1em;
-      margin-left: 0;
+      margin-inline-start: 0;
       font-size: 100%;
-      text-align: left;
+      text-align: start;
     }
   }
   .menu{

--- a/app/modules/entities/components/layouts/items_lists.svelte
+++ b/app/modules/entities/components/layouts/items_lists.svelte
@@ -11,13 +11,12 @@
   const dispatch = createEventDispatcher()
   const bubbleUpComponentEvent = BubbleUpComponentEvent(dispatch)
 
-  export let editionsUris, itemsByEditions, mapWrapperEl, itemsListsWrapperEl
+  export let editionsUris, itemsByEditions, mapWrapperEl, itemsListsWrapperEl, waitingForItems
   export let allItems
   // showMap is false to be able to mount ItemsByCategories
   // to set initialBounds before mounting ItemsMap
   export let showMap = false
   let itemsOnMap
-  let waitingForItems
 
   let fetchedEditionsUris = []
   const getItemsByCategories = async () => {

--- a/app/modules/entities/components/layouts/items_lists/items_by_categories.svelte
+++ b/app/modules/entities/components/layouts/items_lists/items_by_categories.svelte
@@ -6,7 +6,7 @@
   import { I18n, i18n } from '#user/lib/i18n'
   import { scrollToElement } from '#lib/screen'
 
-  export let allItems
+  export let allItems = []
   export let itemsOnMap
   export let displayCover
   export let waitingForItems

--- a/app/modules/entities/components/layouts/section_label.svelte
+++ b/app/modules/entities/components/layouts/section_label.svelte
@@ -39,7 +39,6 @@
   @import "#general/scss/utils";
   .label-wrapper{
     @include display-flex(row, center,space-between);
-    margin: 0.5em;
   }
 
   .left-section{
@@ -48,6 +47,7 @@
   h3{
     @include sans-serif;
     font-size: 1.1rem;
+    margin: 0;
   }
   .show-advanced-list-browser{
     margin-inline-start: 2rem;

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -1,26 +1,26 @@
 <script>
   import { onChange } from '#lib/svelte/svelte'
   import SelectDropdown from '#components/select_dropdown.svelte'
-  import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
+  import { getSortingOptionsByName } from '#entities/components/lib/works_browser_helpers'
   import { I18n } from '#user/lib/i18n'
-  import { waitForOptionPromise } from '#entities/components/lib/sort_entities_by'
+  import { sortEntities } from '#entities/components/lib/sort_entities_by'
 
   export let sortingType = 'work', entities, waitingForItems
 
-  const optionsByNames = getSortingOptionsByNames(sortingType)
-  const options = Object.values(optionsByNames)
-  let sortingName = Object.keys(optionsByNames)?.[0]
+  const optionsByName = getSortingOptionsByName(sortingType)
+  const options = Object.values(optionsByName)
+  let sortingName = Object.keys(optionsByName)?.[0]
 
-  async function sortEntities () {
-    const option = optionsByNames[sortingName]
-    const { sortFunction } = option
-    if (sortFunction) {
-      await waitForOptionPromise(sortingName, waitingForItems, entities)
-      entities = entities.sort(sortFunction)
-    }
+  $: option = optionsByName[sortingName]
+  async function sortEntitiesBy () {
+    entities = await sortEntities({
+      sortingType,
+      option,
+      entities,
+      waitingForItems
+    })
   }
-
-  $: onChange(sortingName, sortEntities)
+  $: onChange(sortingName, sortEntitiesBy)
 </script>
 {#if options.length > 1}
   <div class="sort-selector">

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -6,7 +6,7 @@
   import { getAndAssignPopularity } from '#entities/lib/entities'
   import { I18n } from '#user/lib/i18n'
 
-  export let sortingType = 'works', entities, waitingForItems
+  export let sortingType = 'work', entities, waitingForItems
 
   const optionsByNames = getSortingOptionsByNames(sortingType)
   const options = Object.values(optionsByNames)

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -1,10 +1,9 @@
 <script>
-  import { isNonEmptyArray } from '#lib/boolean_tests'
   import { onChange } from '#lib/svelte/svelte'
   import SelectDropdown from '#components/select_dropdown.svelte'
   import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
-  import { getAndAssignPopularity } from '#entities/lib/entities'
   import { I18n } from '#user/lib/i18n'
+  import { waitForOptionPromise } from '#entities/components/lib/sort_entities_by'
 
   export let sortingType = 'work', entities, waitingForItems
 
@@ -16,31 +15,9 @@
     const option = optionsByNames[sortingName]
     const { sortFunction } = option
     if (sortFunction) {
-      await waitForOptionPromise(sortingName, waitingForItems)
+      await waitForOptionPromise(sortingName, waitingForItems, entities)
       entities = entities.sort(sortFunction)
     }
-  }
-
-  const sortingPromises = {
-    byPopularity: getAndAssignPopularity,
-    byItemsOwnersCount: assignItemsToEditions,
-  }
-
-  async function waitForOptionPromise (sortingName, waitingForPromise) {
-    const promiseFn = sortingPromises[sortingName]
-    if (!promiseFn) return
-    await promiseFn(entities, waitingForPromise)
-  }
-
-  async function assignItemsToEditions (entities, waitingForPromise) {
-    const editionsItems = await waitingForPromise
-    const itemsByEditions = _.groupBy(editionsItems, 'entity')
-    entities.forEach(assignItemsToEdition(itemsByEditions))
-  }
-
-  const assignItemsToEdition = itemsByEditions => edition => {
-    const items = itemsByEditions[edition.uri]
-    if (!edition.items && isNonEmptyArray(items)) edition.items = items
   }
 
   $: onChange(sortingName, sortEntities)

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -2,7 +2,7 @@
   import { onChange } from '#lib/svelte/svelte'
   import SelectDropdown from '#components/select_dropdown.svelte'
   import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
-  import { byPublicationDate, byPopularity, getAndAssignPopularity } from '#entities/lib/entities'
+  import { byPublicationDate, byPopularity, bySerieOrdinal, getAndAssignPopularity } from '#entities/lib/entities'
   import { I18n } from '#user/lib/i18n'
 
   export let sortingType = 'works', entities
@@ -14,6 +14,7 @@
   const sortFunctions = {
     byPublicationDate,
     byPopularity,
+    bySerieOrdinal
   }
 
   async function sortEntities () {

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -21,7 +21,10 @@
     const sortFn = sortFunctions[currentSortingName]
     if (sortFn) {
       if (currentSortingName === 'byPopularity') {
-        await getAndAssignPopularity(entities)
+        let promise = getAndAssignPopularity(entities)
+        const option = optionsByNames.byPopularity
+        option.promise = promise
+        await promise
       }
       entities = entities.sort(sortFn)
     }

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -1,0 +1,50 @@
+<script>
+  import { onChange } from '#lib/svelte/svelte'
+  import SelectDropdown from '#components/select_dropdown.svelte'
+  import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
+  import { byPublicationDate, byPopularity, getAndAssignPopularity } from '#entities/lib/entities'
+  import { I18n } from '#user/lib/i18n'
+
+  export let sortingType = 'works', entities
+
+  const optionsByNames = getSortingOptionsByNames(sortingType)
+  const options = Object.values(optionsByNames)
+  let currentSortingName = Object.keys(optionsByNames)?.[0]
+
+  const sortFunctions = {
+    byPublicationDate,
+    byPopularity,
+  }
+
+  async function sortEntities () {
+    const sortFn = sortFunctions[currentSortingName]
+    if (sortFn) {
+      if (currentSortingName === 'byPopularity') {
+        await getAndAssignPopularity(entities)
+      }
+      entities = entities.sort(sortFn)
+    }
+  }
+  $: onChange(currentSortingName, sortEntities)
+</script>
+{#if options.length > 1}
+  <div class="sort-selector">
+    <SelectDropdown
+      bind:value={currentSortingName}
+      {options}
+      buttonLabel={I18n('sort_by')}
+    />
+  </div>
+{/if}
+<style lang="scss">
+  @import "#general/scss/utils";
+  .sort-selector{
+    align-self: end;
+    :global(.select-dropdown){
+      @include display-flex(row, center, stretch);
+    }
+    :global(.dropdown-content), :global(.dropdown-button){
+      min-width: 10em;
+    }
+  }
+</style>

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -2,7 +2,7 @@
   import { onChange } from '#lib/svelte/svelte'
   import SelectDropdown from '#components/select_dropdown.svelte'
   import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
-  import { byPublicationDate, byPopularity, bySerieOrdinal, getAndAssignPopularity } from '#entities/lib/entities'
+  import { getAndAssignPopularity } from '#entities/lib/entities'
   import { I18n } from '#user/lib/i18n'
 
   export let sortingType = 'works', entities
@@ -11,22 +11,16 @@
   const options = Object.values(optionsByNames)
   let currentSortingName = Object.keys(optionsByNames)?.[0]
 
-  const sortFunctions = {
-    byPublicationDate,
-    byPopularity,
-    bySerieOrdinal
-  }
-
   async function sortEntities () {
-    const sortFn = sortFunctions[currentSortingName]
-    if (sortFn) {
+    const option = optionsByNames[currentSortingName]
+    const { sortFunction } = option
+    if (sortFunction) {
       if (currentSortingName === 'byPopularity') {
         let promise = getAndAssignPopularity(entities)
-        const option = optionsByNames.byPopularity
         option.promise = promise
         await promise
       }
-      entities = entities.sort(sortFn)
+      entities = entities.sort(sortFunction)
     }
   }
   $: onChange(currentSortingName, sortEntities)

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -2,7 +2,7 @@
   import { onChange } from '#lib/svelte/svelte'
   import SelectDropdown from '#components/select_dropdown.svelte'
   import { getSortingOptionsByName } from '#entities/components/lib/works_browser_helpers'
-  import { I18n } from '#user/lib/i18n'
+  import { i18n } from '#user/lib/i18n'
   import { sortEntities } from '#entities/components/lib/sort_entities_by'
 
   export let sortingType = 'work', entities, waitingForItems
@@ -32,7 +32,7 @@
     <SelectDropdown
       bind:value={sortingName}
       {options}
-      buttonLabel={I18n('sort_by')}
+      buttonLabel={i18n('Sort by')}
       on:selectSameOption={reverseOrder}
     />
   </div>

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -20,6 +20,11 @@
       waitingForItems
     })
   }
+
+  function reverseOrder () {
+    entities = entities.reverse()
+  }
+
   $: onChange(sortingName, sortEntitiesBy)
 </script>
 {#if options.length > 1}
@@ -28,6 +33,7 @@
       bind:value={sortingName}
       {options}
       buttonLabel={I18n('sort_by')}
+      on:selectSameOption={reverseOrder}
     />
   </div>
 {/if}

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -50,7 +50,7 @@
       lang: userLang
     })
     publishersByUris = entities
-    await getAndAssignPopularity(initialEditions)
+    await getAndAssignPopularity({ entities: initialEditions })
     editions = initialEditions.sort(byPopularity)
   }
 

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -45,7 +45,7 @@
     const publishersUris = getPublishersUrisFromEditions(initialEditions)
     const { entities } = await getEntitiesAttributesByUris({
       uris: publishersUris,
-      // type is necessary to generate publisher URI link without "wdt:P921-" prefix
+      // info is necessary to get the type, and generate publisher URI link without "wdt:P921-" prefix
       attributes: [ 'info', 'labels' ],
       lang: userLang
     })

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -3,7 +3,7 @@
   import { isNonEmptyArray } from '#lib/boolean_tests'
   import { i18n } from '#user/lib/i18n'
   import { getSubEntities } from '../lib/entities'
-  import { getEntitiesAttributesByUris } from '#entities/lib/entities'
+  import { getEntitiesAttributesByUris, byPopularity, getAndAssignPopularity } from '#entities/lib/entities'
   import { getPublishersUrisFromEditions, omitNonInfoboxClaims } from '#entities/components/lib/work_helpers'
   import BaseLayout from './base_layout.svelte'
   import AuthorsInfo from './authors_info.svelte'
@@ -49,7 +49,8 @@
       lang: userLang
     })
     publishersByUris = entities
-    editions = initialEditions
+    await getAndAssignPopularity(initialEditions)
+    editions = initialEditions.sort(byPopularity)
   }
 
   let waitingForEditions = getEditionsWithPublishers().catch(err => flash = err)

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -36,6 +36,7 @@
   let publishersByUris
   let allItems
   let itemsByEditions = {}
+  let waitingForItems
 
   setContext('work-layout:filters-store', writable({}))
 
@@ -120,6 +121,7 @@
             {initialEditions}
             bind:editions
             bind:itemsByEditions
+            {waitingForItems}
           />
         {/await}
       </div>
@@ -132,6 +134,7 @@
             bind:showMap
             bind:allItems
             bind:itemsByEditions
+            bind:waitingForItems
             bind:mapWrapperEl
             bind:itemsListsWrapperEl
             on:showMapAndScrollToMap={showMapAndScrollToMap}

--- a/app/modules/entities/components/layouts/works_browser_section.svelte
+++ b/app/modules/entities/components/layouts/works_browser_section.svelte
@@ -2,6 +2,7 @@
   import Spinner from '#general/components/spinner.svelte'
   import EntityListRow from '#entities/components/layouts/entity_list_row.svelte'
   import SectionLabel from '#entities/components/layouts/section_label.svelte'
+  import SortEntitiesBy from '#entities/components/layouts/sort_entities_by.svelte'
   import WorkGridCard from '#entities/components/layouts/work_grid_card.svelte'
   import WorkActions from '#entities/components/layouts/work_actions.svelte'
   import { addWorksImages } from '#entities/lib/types/work_alt'
@@ -16,7 +17,7 @@
 
   export let section, displayMode, facets, facetsSelectedValues, textFilterUris
 
-  const { entities: works, searchable = true } = section
+  const { entities: works, searchable = true, sortingType } = section
   let { label, context } = section
 
   let filteredWorks = works
@@ -110,13 +111,21 @@
   class:disabled
   title={disabled ? i18n('Searching is not possible for this section yet') : ''}
 >
-  {#if label}
-    <SectionLabel
-      {label}
-      entitiesLength={works.length}
-      filteredEntitiesLength={filteredWorks.length}
-    />
-  {/if}
+  <div class="title-row">
+    {#if label}
+      <SectionLabel
+        {label}
+        entitiesLength={works.length}
+        filteredEntitiesLength={filteredWorks.length}
+      />
+    {/if}
+    {#if paginatedWorks.length > 1}
+      <SortEntitiesBy
+        {sortingType}
+        bind:entities={filteredWorks}
+      />
+    {/if}
+  </div>
   <Flash bind:state={flash} />
   {#if anyWork}
     <ul
@@ -168,6 +177,10 @@
   }
   .section-without-work{
     @include display-flex(row, center);
+  }
+  .title-row{
+    @include display-flex(row, center, space-between);
+    margin: 0.3em 0.5em;
   }
   ul{
     flex: 1;

--- a/app/modules/entities/components/layouts/works_browser_section.svelte
+++ b/app/modules/entities/components/layouts/works_browser_section.svelte
@@ -111,7 +111,10 @@
   class:disabled
   title={disabled ? i18n('Searching is not possible for this section yet') : ''}
 >
-  <div class="title-row">
+  <div
+    class="title-row"
+    class:empty={!label}
+  >
     {#if label}
       <SectionLabel
         {label}
@@ -170,7 +173,7 @@
     background-color: $off-white;
     padding: 0.5em;
     margin-block-end: 0.5em;
-    @include display-flex(column, flex-start);
+    @include display-flex(column);
     &.disabled{
       opacity: 0.5;
     }

--- a/app/modules/entities/components/lib/edition_action_helpers.js
+++ b/app/modules/entities/components/lib/edition_action_helpers.js
@@ -2,9 +2,9 @@ import { I18n } from '#user/lib/i18n'
 import { property, uniq } from 'underscore'
 import { isNonEmptyArray } from '#lib/boolean_tests'
 
-export const getCounterText = editionItems => I18n('users_count_have_this_book', { smart_count: getOwnersSizePerEdition(editionItems) })
+export const getCounterText = editionItems => I18n('users_count_have_this_book', { smart_count: getOwnersCountPerEdition(editionItems) })
 
-const getOwnersSizePerEdition = editionItems => {
+export const getOwnersCountPerEdition = editionItems => {
   if (isNonEmptyArray(editionItems)) {
     const notMainUserEditions = editionItems.filter(notMainUserOwner)
     const owners = notMainUserEditions.map(property('owner'))

--- a/app/modules/entities/components/lib/entities.js
+++ b/app/modules/entities/components/lib/entities.js
@@ -19,7 +19,7 @@ const urisGetterByType = {
 
     const { parts } = await preq.get(app.API.entities.serieParts(uri, refresh))
     return [
-      { uris: pluck(parts, 'uri'), sortingType: 'parts' },
+      { uris: pluck(parts, 'uri'), sortingType: 'seriePart' },
     ]
   },
   human: async ({ entity, refresh }) => {
@@ -63,7 +63,7 @@ const urisGetterByType = {
     const label = i18n(propLabel, { name: entityLabel })
     let sortingType
     if (property === 'wdt:P69') sortingType = null
-    else sortingType = 'works'
+    else sortingType = 'work'
     return [
       { label, uris, sortingType },
     ]

--- a/app/modules/entities/components/lib/entities.js
+++ b/app/modules/entities/components/lib/entities.js
@@ -61,8 +61,11 @@ const urisGetterByType = {
     const uris = await getReverseClaims(property, uri, refresh)
     const propLabel = inverseLabels[property] || ''
     const label = i18n(propLabel, { name: entityLabel })
+    let sortingType
+    if (property === 'wdt:P69') sortingType = null
+    else sortingType = 'works'
     return [
-      { label, uris },
+      { label, uris, sortingType },
     ]
   }
 }

--- a/app/modules/entities/components/lib/entities.js
+++ b/app/modules/entities/components/lib/entities.js
@@ -19,7 +19,7 @@ const urisGetterByType = {
 
     const { parts } = await preq.get(app.API.entities.serieParts(uri, refresh))
     return [
-      { uris: pluck(parts, 'uri') },
+      { uris: pluck(parts, 'uri'), sortingType: 'parts' },
     ]
   },
   human: async ({ entity, refresh }) => {

--- a/app/modules/entities/components/lib/sort_entities_by.js
+++ b/app/modules/entities/components/lib/sort_entities_by.js
@@ -1,0 +1,36 @@
+import { isNonEmptyArray } from '#lib/boolean_tests'
+import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
+import { getAndAssignPopularity } from '#entities/lib/entities'
+
+const sortingPromises = {
+  byPopularity: getAndAssignPopularity,
+  byItemsOwnersCount: assignItemsToEditions,
+}
+
+export async function sortEntities ({ sortingType, sortingName, entities, waitingForItems }) {
+  const optionsByNames = getSortingOptionsByNames(sortingType)
+  const option = optionsByNames[sortingName]
+  // sortingName = sortingName || Object.keys(optionsByNames)?.[0]
+  const { sortFunction } = option
+  if (sortFunction) {
+    await waitForOptionPromise(sortingName, waitingForItems, entities)
+  }
+  return entities.sort(sortFunction)
+}
+
+export async function waitForOptionPromise (sortingName, waitingForPromise, entities) {
+  const promiseFn = sortingPromises[sortingName]
+  if (!promiseFn) return
+  await promiseFn(entities, waitingForPromise)
+}
+
+export async function assignItemsToEditions (entities, waitingForPromise) {
+  const editionsItems = await waitingForPromise
+  const itemsByEditions = _.groupBy(editionsItems, 'entity')
+  entities.forEach(assignItemsToEdition(itemsByEditions))
+}
+
+export const assignItemsToEdition = itemsByEditions => edition => {
+  const items = itemsByEditions[edition.uri]
+  if (!edition.items && isNonEmptyArray(items)) edition.items = items
+}

--- a/app/modules/entities/components/lib/sort_entities_by.js
+++ b/app/modules/entities/components/lib/sort_entities_by.js
@@ -1,5 +1,4 @@
 import { isNonEmptyArray } from '#lib/boolean_tests'
-import { getSortingOptionsByNames } from '#entities/components/lib/works_browser_helpers'
 import { getAndAssignPopularity } from '#entities/lib/entities'
 
 const sortingPromises = {
@@ -7,25 +6,21 @@ const sortingPromises = {
   byItemsOwnersCount: assignItemsToEditions,
 }
 
-export async function sortEntities ({ sortingType, sortingName, entities, waitingForItems }) {
-  const optionsByNames = getSortingOptionsByNames(sortingType)
-  const option = optionsByNames[sortingName]
-  // sortingName = sortingName || Object.keys(optionsByNames)?.[0]
-  const { sortFunction } = option
-  if (sortFunction) {
-    await waitForOptionPromise(sortingName, waitingForItems, entities)
-  }
+export async function sortEntities ({ sortingType, option, entities, waitingForItems }) {
+  const { sortFunction, value: sortingName } = option
+  if (!sortFunction) return entities
+  await assignSortingDataToEntities(sortingName, waitingForItems, entities)
   return entities.sort(sortFunction)
 }
 
-export async function waitForOptionPromise (sortingName, waitingForPromise, entities) {
+export async function assignSortingDataToEntities (sortingName, waitingForItems, entities) {
   const promiseFn = sortingPromises[sortingName]
   if (!promiseFn) return
-  await promiseFn(entities, waitingForPromise)
+  const editionsItems = await waitingForItems
+  await promiseFn({ entities, editionsItems })
 }
 
-export async function assignItemsToEditions (entities, waitingForPromise) {
-  const editionsItems = await waitingForPromise
+export async function assignItemsToEditions ({ entities, editionsItems }) {
   const itemsByEditions = _.groupBy(editionsItems, 'entity')
   entities.forEach(assignItemsToEdition(itemsByEditions))
 }

--- a/app/modules/entities/components/lib/sort_entities_by.js
+++ b/app/modules/entities/components/lib/sort_entities_by.js
@@ -6,7 +6,7 @@ const sortingPromises = {
   byItemsOwnersCount: assignItemsToEditions,
 }
 
-export async function sortEntities ({ sortingType, option, entities, promise }) {
+export async function sortEntities ({ option, entities, promise }) {
   const { sortFunction, value: sortingName } = option
   if (!sortFunction) return entities
   const sortingPromise = sortingPromises[sortingName]

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -1,4 +1,7 @@
-import { getEntitiesAttributesByUris, getYearFromSimpleDay } from '#entities/lib/entities'
+import {
+  getEntitiesAttributesByUris, getYearFromSimpleDay,
+  byPublicationDate, byPopularity, bySerieOrdinal
+} from '#entities/lib/entities'
 import { propertiesEditorsConfigs } from '#entities/lib/properties'
 import { I18n } from '#user/lib/i18n'
 import { intersection, pluck, uniq } from 'underscore'
@@ -215,20 +218,23 @@ export function isClaimLayout (layoutContext) {
 const publicationDateOption = {
   text: 'publication date',
   value: 'byPublicationDate',
+  sortFunction: byPublicationDate
 }
 
 const popularityOption = {
   text: 'popularity',
   value: 'byPopularity',
+  sortFunction: byPopularity
 }
 
 const serieOrdinalOption = {
   text: 'serie ordinal',
   value: 'bySerieOrdinal',
+  sortFunction: bySerieOrdinal
 }
 
 // sorting options order matters
-let sortFnPerType = {
+let sortFunctionPerType = {
   editions: {
     byPopularity: popularityOption,
     byPublicationDate: publicationDateOption,
@@ -245,5 +251,5 @@ let sortFnPerType = {
 }
 
 export const getSortingOptionsByNames = (type, promiseArguments) => {
-  return sortFnPerType[type]
+  return sortFunctionPerType[type]
 }

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -1,6 +1,6 @@
 import {
   getEntitiesAttributesByUris, getYearFromSimpleDay,
-  byPublicationDate, byPopularity, bySerieOrdinal
+  byPublicationDate, byPopularity, bySerieOrdinal, byItemsOwnersCount
 } from '#entities/lib/entities'
 import { propertiesEditorsConfigs } from '#entities/lib/properties'
 import { I18n } from '#user/lib/i18n'
@@ -233,11 +233,18 @@ const serieOrdinalOption = {
   sortFunction: bySerieOrdinal
 }
 
+const itemsOwnersCountOption = {
+  text: 'users in your network',
+  value: 'byItemsOwnersCount',
+  sortFunction: byItemsOwnersCount
+}
+
 // sorting options order matters
 let sortFunctionPerType = {
   editions: {
     byPopularity: popularityOption,
     byPublicationDate: publicationDateOption,
+    byItemsOwnersCount: itemsOwnersCountOption
   },
   works: {
     byPublicationDate: publicationDateOption,

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -230,8 +230,8 @@ const serieOrdinalOption = {
 // sorting options order matters
 let sortFnPerType = {
   editions: {
-    byPublicationDate: publicationDateOption,
     byPopularity: popularityOption,
+    byPublicationDate: publicationDateOption,
   },
   works: {
     byPublicationDate: publicationDateOption,

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -2,6 +2,7 @@ import {
   getEntitiesAttributesByUris, getYearFromSimpleDay,
   byNewestPublicationDate, byPopularity, bySerieOrdinal, byItemsOwnersCount
 } from '#entities/lib/entities'
+import { sortAlphabetically } from '#entities/components/lib/deduplicate_helpers.js'
 import { propertiesEditorsConfigs } from '#entities/lib/properties'
 import { I18n } from '#user/lib/i18n'
 import { intersection, pluck, uniq } from 'underscore'
@@ -239,22 +240,31 @@ const itemsOwnersCountOption = {
   sortFunction: byItemsOwnersCount
 }
 
+const alphabeticalOption = {
+  text: 'alphabetically',
+  value: 'byAlphabet',
+  sortFunction: sortAlphabetically
+}
+
 // Sorting options order matters
 // as first option will be selected by default
 let sortingFunctionByNameByType = {
   edition: {
     byPopularity: popularityOption,
     byPublicationDate: publicationDateOption,
-    byItemsOwnersCount: itemsOwnersCountOption
+    byItemsOwnersCount: itemsOwnersCountOption,
+    byAlphabet: alphabeticalOption,
   },
   work: {
     byPublicationDate: publicationDateOption,
     byPopularity: popularityOption,
+    byAlphabet: alphabeticalOption,
   },
   seriePart: {
     bySerieOrdinal: serieOrdinalOption,
     byPublicationDate: publicationDateOption,
     byPopularity: popularityOption,
+    byAlphabet: alphabeticalOption,
   },
 }
 

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -241,7 +241,7 @@ const itemsOwnersCountOption = {
 
 // Sorting options order matters
 // as first option will be selected by default
-let sortFunctionPerType = {
+let sortingFunctionByNameByType = {
   edition: {
     byPopularity: popularityOption,
     byPublicationDate: publicationDateOption,
@@ -258,6 +258,6 @@ let sortFunctionPerType = {
   },
 }
 
-export const getSortingOptionsByNames = (type, promiseArguments) => {
-  return sortFunctionPerType[type]
+export const getSortingOptionsByName = type => {
+  return sortingFunctionByNameByType[type]
 }

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -217,31 +217,31 @@ export function isClaimLayout (layoutContext) {
 }
 
 const publicationDateOption = {
-  text: 'publication date',
+  text: I18n('publication date'),
   value: 'byPublicationDate',
   sortFunction: byNewestPublicationDate
 }
 
 const popularityOption = {
-  text: 'popularity',
+  text: I18n('popularity'),
   value: 'byPopularity',
   sortFunction: byPopularity
 }
 
 const serieOrdinalOption = {
-  text: 'serie ordinal',
+  text: I18n('order in the series'),
   value: 'bySerieOrdinal',
   sortFunction: bySerieOrdinal
 }
 
 const itemsOwnersCountOption = {
-  text: 'users in your network',
+  text: I18n('number of items in your network'),
   value: 'byItemsOwnersCount',
   sortFunction: byItemsOwnersCount
 }
 
 const alphabeticalOption = {
-  text: 'alphabetically',
+  text: I18n('alphabetically'),
   value: 'byAlphabet',
   sortFunction: sortAlphabetically
 }

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -222,6 +222,11 @@ const popularityOption = {
   value: 'byPopularity',
 }
 
+const serieOrdinalOption = {
+  text: 'serie ordinal',
+  value: 'bySerieOrdinal',
+}
+
 // sorting options order matters
 let sortFnPerType = {
   editions: {
@@ -229,6 +234,11 @@ let sortFnPerType = {
     byPopularity: popularityOption,
   },
   works: {
+    byPublicationDate: publicationDateOption,
+    byPopularity: popularityOption,
+  },
+  parts: {
+    bySerieOrdinal: serieOrdinalOption,
     byPublicationDate: publicationDateOption,
     byPopularity: popularityOption,
   },

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -1,6 +1,6 @@
 import {
   getEntitiesAttributesByUris, getYearFromSimpleDay,
-  byPublicationDate, byPopularity, bySerieOrdinal, byItemsOwnersCount
+  byNewestPublicationDate, byPopularity, bySerieOrdinal, byItemsOwnersCount
 } from '#entities/lib/entities'
 import { propertiesEditorsConfigs } from '#entities/lib/properties'
 import { I18n } from '#user/lib/i18n'
@@ -218,7 +218,7 @@ export function isClaimLayout (layoutContext) {
 const publicationDateOption = {
   text: 'publication date',
   value: 'byPublicationDate',
-  sortFunction: byPublicationDate
+  sortFunction: byNewestPublicationDate
 }
 
 const popularityOption = {

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -207,3 +207,33 @@ export function getSelectedUris ({ works, facets, facetsSelectedValues }) {
 export const bySearchMatchScore = textFilterUris => (a, b) => {
   return textFilterUris.indexOf(a.uri) - textFilterUris.indexOf(b.uri)
 }
+
+export function isClaimLayout (layoutContext) {
+  return [ 'genre', 'subject', 'movement' ].includes(layoutContext)
+}
+
+const publicationDateOption = {
+  text: 'publication date',
+  value: 'byPublicationDate',
+}
+
+const popularityOption = {
+  text: 'popularity',
+  value: 'byPopularity',
+}
+
+// sorting options order matters
+let sortFnPerType = {
+  editions: {
+    byPublicationDate: publicationDateOption,
+    byPopularity: popularityOption,
+  },
+  works: {
+    byPublicationDate: publicationDateOption,
+    byPopularity: popularityOption,
+  },
+}
+
+export const getSortingOptionsByNames = (type, promiseArguments) => {
+  return sortFnPerType[type]
+}

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -239,18 +239,19 @@ const itemsOwnersCountOption = {
   sortFunction: byItemsOwnersCount
 }
 
-// sorting options order matters
+// Sorting options order matters
+// as first option will be selected by default
 let sortFunctionPerType = {
-  editions: {
+  edition: {
     byPopularity: popularityOption,
     byPublicationDate: publicationDateOption,
     byItemsOwnersCount: itemsOwnersCountOption
   },
-  works: {
+  work: {
     byPublicationDate: publicationDateOption,
     byPopularity: popularityOption,
   },
-  parts: {
+  seriePart: {
     bySerieOrdinal: serieOrdinalOption,
     byPublicationDate: publicationDateOption,
     byPopularity: popularityOption,

--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -141,7 +141,10 @@ export async function getEntitiesBasicInfoByUris (uris) {
 }
 
 export async function getAndAssignPopularity (entities) {
-  const uris = pluck(entities, 'uri')
+  const uris = []
+  entities.forEach(entity => {
+    if (entity.popularity === undefined) uris.push(entity.uri)
+  })
   if (!isNonEmptyArray(uris)) return entities
   // Limiting refresh to not overcrowd Wikidata
   const refresh = uris.length < 30

--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -6,6 +6,7 @@ import getOriginalLang from './get_original_lang.js'
 import { forceArray } from '#lib/utils'
 import { chunk, compact, indexBy, pluck } from 'underscore'
 import assert_ from '#lib/assert_types'
+import { getOwnersCountPerEdition } from '#entities/components/lib/edition_action_helpers'
 
 export async function getReverseClaims (property, value, refresh, sort) {
   const { uris } = await preq.get(app.API.entities.reverseClaims(property, value, refresh, sort))
@@ -212,6 +213,11 @@ export const byPublicationDate = (a, b) => {
 export function byPopularity (a, b) {
   // Descending order
   return parseInt(b.popularity || 0) - parseInt(a.popularity || 0)
+}
+
+export function byItemsOwnersCount (a, b) {
+  // Descending order
+  return parseInt(getOwnersCountPerEdition(b.items) || 0) - parseInt(getOwnersCountPerEdition(a.items) || 0)
 }
 
 export const getPublicationYear = entity => {

--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -142,12 +142,17 @@ export async function getEntitiesBasicInfoByUris (uris) {
 
 export async function getAndAssignPopularity (entities) {
   const uris = []
+  let wdUrisCount = 0
   entities.forEach(entity => {
-    if (entity.popularity === undefined) uris.push(entity.uri)
+    const { uri } = entity
+    if (entity.popularity === undefined) {
+      uris.push(uri)
+      if (uri.startsWith('wd:')) wdUrisCount++
+    }
   })
   if (!isNonEmptyArray(uris)) return entities
   // Limiting refresh to not overcrowd Wikidata
-  const refresh = uris.length < 30
+  const refresh = wdUrisCount < 30
   const urisChunks = chunk(uris, 30)
   const responses = await Promise.all(urisChunks.map(async urisChunk => {
     return preq.get(app.API.entities.popularity(urisChunk, refresh))

--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -210,6 +210,11 @@ export const byPublicationDate = (a, b) => {
   return parseInt(a.publicationYear || 10000) - parseInt(b.publicationYear || 10000)
 }
 
+export const byNewestPublicationDate = (a, b) => {
+  // Descending order
+  return parseInt(b.publicationYear || 0) - parseInt(a.publicationYear || 0)
+}
+
 export function byPopularity (a, b) {
   // Descending order
   return parseInt(b.popularity || 0) - parseInt(a.popularity || 0)

--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -141,7 +141,7 @@ export async function getEntitiesBasicInfoByUris (uris) {
   })
 }
 
-export async function getAndAssignPopularity (entities) {
+export async function getAndAssignPopularity ({ entities }) {
   const uris = []
   let wdUrisCount = 0
   entities.forEach(entity => {

--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -43,7 +43,9 @@
   function assignNewValue (option) {
     if (value === option.value) {
       dispatch('selectSameOption')
-    } else value = option.value
+    } else {
+      value = option.value
+    }
   }
 </script>
 

--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -8,6 +8,8 @@
   import { icon } from '#lib/utils'
   import { I18n } from '#user/lib/i18n'
   import { uniqueId } from 'underscore'
+  import { createEventDispatcher } from 'svelte'
+  const dispatch = createEventDispatcher()
 
   export let value
   export let resetValue = null
@@ -36,6 +38,12 @@
     const currentOptionIndex = options.indexOf(currentOption)
     const nextOption = options[currentOptionIndex + indexIncrement]
     if (nextOption) value = nextOption.value
+  }
+
+  function assignNewValue (option) {
+    if (value === option.value) {
+      dispatch('selectSameOption')
+    } else value = option.value
   }
 </script>
 
@@ -79,7 +87,7 @@
               role="option"
               title={option.text}
               aria-selected={option.value === value}
-              on:click={() => value = option.value}
+              on:click={() => assignNewValue(option)}
             >
               <SelectDropdownOption {option} {withImage} />
             </button>

--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -57,7 +57,7 @@
     buttonRole="listbox"
   >
     <div slot="button-inner">
-      <SelectDropdownOption option={currentOption} {withImage} />
+      <SelectDropdownOption option={currentOption} {withImage} promise={currentOption.promise} />
       {#if resetValue && value !== resetValue}
         <button
           class="reset"

--- a/app/modules/general/components/select_dropdown_option.svelte
+++ b/app/modules/general/components/select_dropdown_option.svelte
@@ -1,4 +1,5 @@
 <script>
+  import Spinner from '#general/components/spinner.svelte'
   import { icon, truncateText } from '#lib/utils'
   import { imgSrc } from '#lib/handlebars_helpers/images'
   export let option, withImage = false, displayCount = true
@@ -26,6 +27,9 @@
       <span class="count">({option.count})</span>
     {/if}
   </span>
+  {#await option.promise}
+    <Spinner />
+  {/await}
 </div>
 
 <style lang="scss">


### PR DESCRIPTION
solving #114 (5yrs old 🎂 )

The main difficulty was to handle the different sorting by default server side, to be able to recover the initial state of the page. Harmonization server side could have made sense at first sight, but having an agnostic client which store the initial entities sorting felt more future proof, although saving initial server sorting felt like overkill. So instead, the client always treat the entities order as `publicationDate` sorting by default for entity types that a have `wdt:P577` claims, otherwise no sorting is possible by the user (ie. P69 humans)), else the default sorting is by popularity.