### PR TITLE
Add entity links to edition layout

### DIFF
--- a/app/modules/entities/components/layouts/authors_info.svelte
+++ b/app/modules/entities/components/layouts/authors_info.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { I18n } from '#user/lib/i18n'
+  import { i18n } from '#user/lib/i18n'
   import Spinner from '#general/components/spinner.svelte'
   import { isNonEmptyArray, isNonEmptyPlainObject } from '#lib/boolean_tests'
   import { getEntitiesAttributesFromClaims } from '#entities/lib/entities'
@@ -35,7 +35,7 @@
       {#each Object.keys(propertiesByRoles) as role}
         {#if hasPropertiesToDisplay(role)}
           <div class="{role} authors-role">
-            <span class="label">{I18n(role)}</span>
+            <span class="label">{i18n(role)}</span>
             <div class="authors">
               {#each propertiesByRoles[role] as prop}
                 {#if claims[prop]}

--- a/app/modules/entities/components/layouts/claim_infobox.svelte
+++ b/app/modules/entities/components/layouts/claim_infobox.svelte
@@ -38,6 +38,6 @@
 <style lang="scss">
   @import "#general/scss/utils";
   .property{
-    color: $grey;
+    color: $label-grey;
   }
 </style>

--- a/app/modules/entities/components/layouts/ebooks.svelte
+++ b/app/modules/entities/components/layouts/ebooks.svelte
@@ -1,7 +1,7 @@
 <script>
   import { formatEbooksClaim } from '#entities/components/lib/claims_helpers'
   import { isNonEmptyArray } from '#lib/boolean_tests'
-  import { I18n, i18n } from '#user/lib/i18n'
+  import { i18n } from '#user/lib/i18n'
   import Link from '#lib/components/link.svelte'
   import sitelinks_ from '#lib/wikimedia/sitelinks'
 
@@ -24,7 +24,7 @@
 </script>
 {#if isNonEmptyArray(ebooksData)}
   <div class="ebooks">
-    <span>{I18n('ebooks')}:</span>
+    <span>{i18n('ebooks')}:</span>
     {#each ebooksData as value}
       <Link
         url={value.url}
@@ -44,7 +44,7 @@
   @import "#general/scss/utils";
   .ebooks{
     @include display-flex(row, center, flex-start, wrap);
-    margin-top: 1em;
+    color: $label-grey;
     :global(.icon){
       margin-left: 0.6em;
       margin-right: 0.4em;

--- a/app/modules/entities/components/layouts/edition.svelte
+++ b/app/modules/entities/components/layouts/edition.svelte
@@ -8,7 +8,7 @@
   import ItemsLists from './items_lists.svelte'
   import EditionActions from './edition_actions.svelte'
   import OtherEditions from './other_editions.svelte'
-  import { addWorksClaims, filterClaims } from '#entities/components/lib/edition_layout_helpers'
+  import { addWorksClaims } from '#entities/components/lib/edition_layout_helpers'
   import Summary from '#entities/components/layouts/summary.svelte'
   import { tick } from 'svelte'
   import { getEntityMetadata } from '#entities/lib/document_metadata'
@@ -21,8 +21,6 @@
   const { uri, image, label } = entity
   let { claims } = entity
 
-  const claimsWithWorksClaims = _.pick(claims, filterClaims)
-
   async function showMapAndScrollToMap () {
     showMap = true
     await tick()
@@ -30,7 +28,7 @@
   }
 
   $: app.navigate(`/entity/${uri}`, { metadata: getEntityMetadata(entity) })
-  $: claims = addWorksClaims(claimsWithWorksClaims, works)
+  $: claims = addWorksClaims(claims, works)
 </script>
 <BaseLayout
   {entity}

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -87,11 +87,11 @@
           claims={infoboxClaims}
           entityType={entity.type}
         />
-        <Summary {entity} />
         <Ebooks
           {entity}
           {userLang}
         />
+        <Summary {entity} />
         <WorkActions
           {entity}
           {someEditions}

--- a/app/modules/entities/components/lib/edition_layout_helpers.js
+++ b/app/modules/entities/components/lib/edition_layout_helpers.js
@@ -1,4 +1,4 @@
-import { aggregateWorksClaims, infoboxPropertiesByType } from '#entities/components/lib/claims_helpers'
+import { aggregateWorksClaims } from '#entities/components/lib/claims_helpers'
 import { isNonEmptyArray } from '#lib/boolean_tests'
 
 export const addWorksClaims = (claims, works) => {
@@ -6,8 +6,6 @@ export const addWorksClaims = (claims, works) => {
   const nonEmptyWorksClaims = _.pick(worksClaims, isNonEmptyArray)
   return Object.assign(claims, nonEmptyWorksClaims)
 }
-
-export const filterClaims = (_, key) => infoboxPropertiesByType.edition.includes(key)
 
 export const isSubentitiesTypeEdition = type => [
   'collection',

--- a/app/modules/entities/lib/entity_links.js
+++ b/app/modules/entities/lib/entity_links.js
@@ -1,4 +1,4 @@
-import { I18n } from '#user/lib/i18n'
+import { i18n } from '#user/lib/i18n'
 import { groupBy } from 'underscore'
 import { isNonEmptyArray } from '#lib/boolean_tests'
 
@@ -33,6 +33,6 @@ export const getDisplayedPropertiesByCategory = () => {
 }
 
 export const categoryLabels = {
-  bibliographicDatabases: I18n('bibliographic databases'),
-  socialNetworks: I18n('social networks'),
+  bibliographicDatabases: i18n('bibliographic databases'),
+  socialNetworks: i18n('social networks'),
 }


### PR DESCRIPTION
Address #391 as a prefiltering function was removing too many claims from edition layout, preventing to display bibliographical databases links (solved by commit 58d0ab281ae9809d1fd6727f122cec5ef4b30afc)
This PR also take advantage of context to push some cosmetic commits