### PR TITLE
scss: prevent max-width media queries to include the thresold value

### DIFF
--- a/app/modules/entities/components/editor/claim_editor.svelte
+++ b/app/modules/entities/components/editor/claim_editor.svelte
@@ -186,7 +186,7 @@
       margin-bottom: 1em;
     }
     /* Small screens */
-    @media screen and (max-width: $smaller-screen){
+    @media screen and (max-width: $below-smaller-screen){
       flex-direction: column;
       padding: 0.5em 0.2em;
       margin: 0.5em 0;

--- a/app/modules/entities/components/editor/display_mode_buttons.svelte
+++ b/app/modules/entities/components/editor/display_mode_buttons.svelte
@@ -22,7 +22,7 @@
     font-weight: normal;
   }
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     button{
       padding: 0.3em 0.5em;
       margin: 0.2em;

--- a/app/modules/entities/components/editor/edit_mode_buttons.svelte
+++ b/app/modules/entities/components/editor/edit_mode_buttons.svelte
@@ -52,7 +52,7 @@
     background-color: $dark-grey;
   }
   /* Small screens */
-  @media screen and (max-width: $very-small-screen){
+  @media screen and (max-width: $below-very-small-screen){
     button{
       padding: 0.5em;
       margin: 0.2em;

--- a/app/modules/entities/components/editor/entity_edit.svelte
+++ b/app/modules/entities/components/editor/entity_edit.svelte
@@ -92,7 +92,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .header{
       @include display-flex(row, center, space-between, wrap);
     }

--- a/app/modules/entities/components/editor/entity_edit_menu.svelte
+++ b/app/modules/entities/components/editor/entity_edit_menu.svelte
@@ -140,8 +140,9 @@
   @import "#general/scss/utils";
   .menu-wrapper{
     $entity-edit-max-width: 40em;
+    $below-entity-edit-max-width: calc($entity-edit-max-width - 0.01em);
     /* Small screens */
-    @media screen and (max-width: $entity-edit-max-width){
+    @media screen and (max-width: $below-entity-edit-max-width){
       margin-right: 0.5em;
       padding: 0.5em;
     }

--- a/app/modules/entities/components/editor/labels_editor.svelte
+++ b/app/modules/entities/components/editor/labels_editor.svelte
@@ -194,7 +194,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     select{
       margin-bottom: 0.5em;
     }

--- a/app/modules/entities/components/editor/simple_day_value_input.svelte
+++ b/app/modules/entities/components/editor/simple_day_value_input.svelte
@@ -99,7 +99,7 @@
   .wrapper{
     margin-right: auto;
     /* Small screens */
-    @media screen and (max-width: $smaller-screen){
+    @media screen and (max-width: $below-smaller-screen){
       margin-left: auto;
     }
   }

--- a/app/modules/entities/components/entity_autocomplete_selector.svelte
+++ b/app/modules/entities/components/entity_autocomplete_selector.svelte
@@ -280,7 +280,7 @@
       z-index: 1;
     }
     /* Small screens */
-    @media screen and (max-width: $small-screen){
+    @media screen and (max-width: $below-small-screen){
       width: 100%;
     }
     background-color: white;

--- a/app/modules/entities/components/layouts/base_layout.svelte
+++ b/app/modules/entities/components/layouts/base_layout.svelte
@@ -70,7 +70,7 @@
     }
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .header-wrapper{
       @include display-flex(row, center, space-between);
     }
@@ -79,7 +79,7 @@
     }
   }
   /* Very Small screens */
-  @media screen and (max-width: $very-small-screen){
+  @media screen and (max-width: $below-very-small-screen){
     .layout{
       padding: 0 0.5em;
     }

--- a/app/modules/entities/components/layouts/edition.svelte
+++ b/app/modules/entities/components/layouts/edition.svelte
@@ -129,7 +129,7 @@
     }
   }
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .info-wrapper{
       @include display-flex(column, center, center);
       margin-top: 1em;
@@ -142,7 +142,7 @@
     }
   }
   /* Very small screens */
-  @media screen and (max-width: $very-small-screen){
+  @media screen and (max-width: $below-very-small-screen){
     .author-and-info{
       margin-right: 0;
     }

--- a/app/modules/entities/components/layouts/edition_actions.svelte
+++ b/app/modules/entities/components/layouts/edition_actions.svelte
@@ -50,7 +50,7 @@
     padding: 0.5em;
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .add-to-my-inventory{
       @include display-flex(row);
       margin-bottom: 0.5em;

--- a/app/modules/entities/components/layouts/entity_list_element.svelte
+++ b/app/modules/entities/components/layouts/entity_list_element.svelte
@@ -127,7 +127,7 @@
     margin: 0 1em;
   }
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .entity-wrapper{
       flex-wrap: wrap;
     }

--- a/app/modules/entities/components/layouts/items_lists.svelte
+++ b/app/modules/entities/components/layouts/items_lists.svelte
@@ -88,7 +88,7 @@
     @include radius;
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .close-map-button{
       padding: 0.3em;
     }

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -203,7 +203,7 @@
     align-self: stretch;
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .work-section{
       margin-left: 0;
       :global(.claims-infobox-wrapper){

--- a/app/modules/entities/components/layouts/works_browser.svelte
+++ b/app/modules/entities/components/layouts/works_browser.svelte
@@ -138,7 +138,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .controls{
       flex-wrap: wrap;
       :global(.select-dropdown), :global(.works-browser-text-filter){
@@ -148,7 +148,7 @@
   }
 
   /* Very small screens */
-  @media screen and (max-width: $very-small-screen){
+  @media screen and (max-width: $below-very-small-screen){
     .wrapper:not(.unwrapped){
       @include display-flex(column, center);
     }

--- a/app/modules/entities/scss/_items_preview_list.scss
+++ b/app/modules/entities/scss/_items_preview_list.scss
@@ -48,7 +48,7 @@ $preview-icon-base-size: 2em;
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     @include display-flex(column, center, flex-start);
   }
 }

--- a/app/modules/entities/scss/_patch_operations.scss
+++ b/app/modules/entities/scss/_patch_operations.scss
@@ -42,7 +42,7 @@
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .patch{
       flex-wrap: wrap;
     }

--- a/app/modules/entities/scss/_serie_cleanup_controls.scss
+++ b/app/modules/entities/scss/_serie_cleanup_controls.scss
@@ -66,7 +66,7 @@
 }
 
 /*Small screens*/
-@media screen and (max-width: $small-screen) {
+@media screen and (max-width: $below-small-screen) {
   .controls-section{
     @include display-flex(row, center, center, wrap);
   }

--- a/app/modules/entities/scss/_work_infobox.scss
+++ b/app/modules/entities/scss/_work_infobox.scss
@@ -53,7 +53,7 @@ $work-infobox-property-color: #999;
     text-align: center;
   }
   /*Very Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     .covers{
       align-self: stretch;
       flex-direction: column;

--- a/app/modules/entities/scss/article_li.scss
+++ b/app/modules/entities/scss/article_li.scss
@@ -60,7 +60,7 @@
     @include text-hover($grey, $dark-grey);
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     flex-direction: column;
   }
 }

--- a/app/modules/entities/scss/author_layout.scss
+++ b/app/modules/entities/scss/author_layout.scss
@@ -63,7 +63,7 @@
       color: white;
     }
     /*Small screens*/
-    @media screen and (max-width: $smaller-screen) {
+    @media screen and (max-width: $below-smaller-screen) {
       .authorData{
         flex-direction: column;
       }

--- a/app/modules/entities/scss/edition_creation.scss
+++ b/app/modules/entities/scss/edition_creation.scss
@@ -28,7 +28,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     padding: 1em;
     flex-direction: column;
     align-items: stretch;

--- a/app/modules/entities/scss/edition_li.scss
+++ b/app/modules/entities/scss/edition_li.scss
@@ -24,7 +24,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     @include display-flex(column, center, center);
     padding-top: 1em;
     margin-bottom: 1em;

--- a/app/modules/entities/scss/entities_infoboxes.scss
+++ b/app/modules/entities/scss/entities_infoboxes.scss
@@ -1,6 +1,7 @@
 @import '#general/scss/utils';
 
 $author-data-threshold: 25em;
+$below-author-data-threshold: calc($author-data-threshold - 0.01em);
 
 .authorInfobox, .publisherInfobox, .collectionInfobox{
   margin: 0 auto;
@@ -49,7 +50,7 @@ $author-data-threshold: 25em;
   margin-bottom: 1em;
   color: white;
   /*Small screens*/
-  @media screen and (max-width: $author-data-threshold) {
+  @media screen and (max-width: $below-author-data-threshold) {
     // Give some room to a.edit .fa-pencil
     min-width: 90vw
   }

--- a/app/modules/entities/scss/entities_layouts.scss
+++ b/app/modules/entities/scss/entities_layouts.scss
@@ -80,7 +80,7 @@ $author-layout-bg: #292929;
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .workLi:first-child:not(.wrappable){
       margin-top: 1em;
     }

--- a/app/modules/entities/scss/entities_list_adder.scss
+++ b/app/modules/entities/scss/entities_list_adder.scss
@@ -95,7 +95,7 @@
 }
 
 /*Very Small screens*/
-@media screen and (max-width: $smaller-screen) {
+@media screen and (max-width: $below-smaller-screen) {
   #entitiesListAdder{
     padding: 0 0.5em;
   }

--- a/app/modules/entities/scss/entity_actions.scss
+++ b/app/modules/entities/scss/entity_actions.scss
@@ -3,7 +3,7 @@
   @include display-flex(column, center, center);
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     flex-direction: column;
     .button-group > li{
       margin: 0;

--- a/app/modules/entities/scss/entity_editors_commons.scss
+++ b/app/modules/entities/scss/entity_editors_commons.scss
@@ -10,7 +10,7 @@
     padding: 1em 1.5em;
   }
   /*Small screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     flex-direction: column;
     padding: 0.4em;
   }

--- a/app/modules/entities/scss/work_li.scss
+++ b/app/modules/entities/scss/work_li.scss
@@ -1,9 +1,10 @@
 @import '#general/scss/utils';
-$workLiMaxWidth: 45em;
+$work-li-max-width: 45em;
+$below-work-li-max-width: calc($work-li-max-width - 0.01em);
 
 .workLi{
   margin: 0 auto;
-  max-width: $workLiMaxWidth;
+  max-width: $work-li-max-width;
   background-color: $contrast;
   &:not(:first-child):not(.wrappable){
     margin-top: 1em;
@@ -93,7 +94,7 @@ $workLiMaxWidth: 45em;
 }
 
 /*Small screens*/
-@media screen and (max-width: $workLiMaxWidth) {
+@media screen and (max-width: $below-work-li-max-width) {
   .workLi{
     max-width: 100vw;
     @include display-flex(column);
@@ -114,7 +115,7 @@ $workLiMaxWidth: 45em;
 }
 
 /*Large screens*/
-@media screen and (min-width: $workLiMaxWidth) {
+@media screen and (min-width: $work-li-max-width) {
   .workLi{
     .workCover{
       margin: 1em;

--- a/app/modules/general/components/facet_selector.svelte
+++ b/app/modules/general/components/facet_selector.svelte
@@ -153,7 +153,7 @@
     @include shy;
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .facet-selector{
       margin-top: 1.6em;
     }

--- a/app/modules/general/components/modal.svelte
+++ b/app/modules/general/components/modal.svelte
@@ -95,7 +95,7 @@
     }
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .modal-outer{
       margin: 0.5em 0;
       padding: 0.5em;

--- a/app/modules/general/scss/_app_layout.scss
+++ b/app/modules/general/scss/_app_layout.scss
@@ -9,7 +9,7 @@ main{
   position: relative;
   z-index: 0;
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     // Allow screen_.scrollTop to really get the top of the div
     // at the top of the screen, which would not be possible
     // if main was smaller than the screen

--- a/app/modules/general/scss/_custom_tabs.scss
+++ b/app/modules/general/scss/_custom_tabs.scss
@@ -1,16 +1,17 @@
-$customTabMaxWidth: 40em;
+$custom-tab-max-width: 40em;
+$below-custom-tab-max-width: calc($custom-tab-max-width - 0.01em);
 
 .custom-tabs{
   @include display-flex(column, left);
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     width: 100%;
   }
 
   /*Large screens*/
   @media screen and (min-width: $small-screen) {
-    width: $customTabMaxWidth;
+    width: $custom-tab-max-width;
   }
 }
 
@@ -36,7 +37,7 @@ $customTabMaxWidth: 40em;
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $customTabMaxWidth) {
+  @media screen and (max-width: $below-custom-tab-max-width) {
     flex-wrap: wrap;
     width: 100%;
     .active{
@@ -65,11 +66,11 @@ $customTabMaxWidth: 40em;
   @include radius-bottom;
   border-top-right-radius: $global-radius;
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     padding: 0.5em;
   }
   /*Large screens*/
-  @media screen and (min-width: $customTabMaxWidth) {
+  @media screen and (min-width: $custom-tab-max-width) {
     padding: 2em;
   }
 }

--- a/app/modules/general/scss/_flash_message.scss
+++ b/app/modules/general/scss/_flash_message.scss
@@ -27,7 +27,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     left: 0;
     &.active{
       top: auto;

--- a/app/modules/general/scss/_img.scss
+++ b/app/modules/general/scss/_img.scss
@@ -35,7 +35,7 @@ figure{
 }
 
 /*Small screens*/
-@media screen and (max-width: $small-screen) {
+@media screen and (max-width: $below-small-screen) {
   .max-large-profilePic{
     max-width: 90%;
     max-height: 10em;

--- a/app/modules/general/scss/_input.scss
+++ b/app/modules/general/scss/_input.scss
@@ -100,7 +100,7 @@ label{
   }
 
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     flex-direction: column;
     button{
       width: 100%;
@@ -131,7 +131,7 @@ label{
     margin-bottom: 0;
   }
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     width: 100%;
     input{
       margin: 0 !important;

--- a/app/modules/general/scss/_media_query_thresholds.scss
+++ b/app/modules/general/scss/_media_query_thresholds.scss
@@ -3,3 +3,7 @@
 $small-screen: 1000px;
 $smaller-screen: 600px;
 $very-small-screen: 350px;
+
+$below-small-screen: calc($small-screen - 1px);
+$below-smaller-screen: calc($smaller-screen - 1px);
+$below-very-small-screen: calc($very-small-screen - 1px);

--- a/app/modules/general/scss/_modal.scss
+++ b/app/modules/general/scss/_modal.scss
@@ -37,7 +37,7 @@ body.openedModal{
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     padding: 2em 0.2em;
     min-width: 80vw;
     margin-top: 10px;
@@ -67,7 +67,7 @@ body.openedModal{
   }
   box-shadow: 3px 3px 10px 3px rgba(#222, 0.5);
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     padding: 1em 0;
   }
   /*Large screens*/

--- a/app/modules/general/scss/_shortcut_tip.scss
+++ b/app/modules/general/scss/_shortcut_tip.scss
@@ -9,7 +9,7 @@
   margin-right: 1em;
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     // doing shortcuts in mobile is quite hard
     display: none;
   }

--- a/app/modules/general/scss/_top_bar.scss
+++ b/app/modules/general/scss/_top_bar.scss
@@ -101,7 +101,7 @@ nav#top-bar{
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     padding: 0.2em 0;
     h1{
       flex: 0 0 auto;
@@ -138,7 +138,7 @@ nav#top-bar{
     }
   }
   /*Smaller screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     .current-lang{
       display: none;
     }

--- a/app/modules/general/scss/_top_bar_buttons.scss
+++ b/app/modules/general/scss/_top_bar_buttons.scss
@@ -19,7 +19,7 @@
       padding: 0 0.5em;
     }
     /*Small screens*/
-    @media screen and (max-width: $small-screen) {
+    @media screen and (max-width: $below-small-screen) {
       margin-left: 0.2em;
       align-self: stretch;
       .fa-bars{
@@ -37,7 +37,7 @@
 
   [role="menu"]{
     /*Very Small screens*/
-    @media screen and (max-width: $very-small-screen) {
+    @media screen and (max-width: $below-very-small-screen) {
       // Going over 100vw to cover the whole screen
       min-width: 102vw;
     }
@@ -70,7 +70,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .label{
       margin-right: 1em;
     }

--- a/app/modules/general/scss/error_layout.scss
+++ b/app/modules/general/scss/error_layout.scss
@@ -26,7 +26,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     .errorBox{
       padding: 1em;
     }

--- a/app/modules/general/scss/panel_utils.scss
+++ b/app/modules/general/scss/panel_utils.scss
@@ -4,7 +4,7 @@
   @include radius;
   padding: 0.8em 1em 0.8em 1em;
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     margin: 0.2em 0 0.3em 0;
   }
   /*Medium to Large screens*/

--- a/app/modules/general/scss/picture_picker.scss
+++ b/app/modules/general/scss/picture_picker.scss
@@ -42,7 +42,7 @@
   img.original{
     max-width: 50em;
     /*Small screens*/
-    @media screen and (max-width: $small-screen) {
+    @media screen and (max-width: $below-small-screen) {
       max-width: 95vw;
     }
     @include radius-top;

--- a/app/modules/groups/components/group_profile.svelte
+++ b/app/modules/groups/components/group_profile.svelte
@@ -162,7 +162,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .group-profile{
       @include display-flex(column, stretch, center);
     }

--- a/app/modules/groups/scss/_group_actions.scss
+++ b/app/modules/groups/scss/_group_actions.scss
@@ -28,7 +28,7 @@
     margin: 0 0 0.5em 0;
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .actions{
       a{
         margin: 0;

--- a/app/modules/groups/scss/group_li.scss
+++ b/app/modules/groups/scss/group_li.scss
@@ -33,7 +33,7 @@
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     flex-direction: column;
     .showGroup{
       @include display-flex(column, center, center);

--- a/app/modules/inventory/components/importer/import_layout.svelte
+++ b/app/modules/inventory/components/importer/import_layout.svelte
@@ -59,7 +59,7 @@
     margin: 0 auto;
     max-width: 50em;
     /* Small screens */
-    @media screen and (max-width: $small-screen){
+    @media screen and (max-width: $below-small-screen){
       margin: 0 0.5em;
     }
   }

--- a/app/modules/inventory/components/inventory_browser_controls.svelte
+++ b/app/modules/inventory/components/inventory_browser_controls.svelte
@@ -144,7 +144,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .controls{
       flex-direction: column;
     }

--- a/app/modules/inventory/components/item_row.svelte
+++ b/app/modules/inventory/components/item_row.svelte
@@ -212,7 +212,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .item-row{
       align-self: stretch;
       min-height: $item-row-height-base;

--- a/app/modules/inventory/components/item_show.svelte
+++ b/app/modules/inventory/components/item_show.svelte
@@ -195,7 +195,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .item-show{
       padding: 0 0.5em;
     }

--- a/app/modules/inventory/components/items_table_selection_editor.svelte
+++ b/app/modules/inventory/components/items_table_selection_editor.svelte
@@ -191,7 +191,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .buttons{
       align-self: stretch;
       @include display-flex(column, stretch, center);

--- a/app/modules/inventory/components/transaction_selector.svelte
+++ b/app/modules/inventory/components/transaction_selector.svelte
@@ -90,7 +90,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     fieldset{
       flex-direction: column;
     }

--- a/app/modules/inventory/scss/_item_card_box.scss
+++ b/app/modules/inventory/scss/_item_card_box.scss
@@ -17,7 +17,7 @@
       }
     }
     /*Small screens*/
-    @media screen and (max-width: $small-screen) {
+    @media screen and (max-width: $below-small-screen) {
       &:not(:last-child){
         margin-bottom: 1em;
       }

--- a/app/modules/inventory/scss/_search_history.scss
+++ b/app/modules/inventory/scss/_search_history.scss
@@ -28,7 +28,7 @@
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     .previous-search{
       a{
         flex-flow: column-reverse;

--- a/app/modules/inventory/scss/add_layout.scss
+++ b/app/modules/inventory/scss/add_layout.scss
@@ -36,14 +36,14 @@ $addLayoutWidth: 70em;
   }
 
   /*Very Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     h3{
       margin-top: 1em;
     }
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .custom-tabs-content{
       // allow screen_.scrollTop to really get the top of the div
       // at the top of the screen

--- a/app/modules/inventory/scss/scan_layout.scss
+++ b/app/modules/inventory/scss/scan_layout.scss
@@ -14,7 +14,7 @@ $scan-contrast: #f5f5f5;
       margin-right: 0.5em;
     }
     /*Small screens*/
-    @media screen and (max-width: $small-screen) {
+    @media screen and (max-width: $below-small-screen) {
       // make it stand-out more
       margin-top: 2em;
       margin-bottom: 2em;

--- a/app/modules/listings/components/listing_element.svelte
+++ b/app/modules/listings/components/listing_element.svelte
@@ -86,7 +86,7 @@
     white-space: nowrap;
   }
   /* Very small screens */
-  @media screen and (max-width: $very-small-screen){
+  @media screen and (max-width: $below-very-small-screen){
     li{
       @include display-flex(column, flex-start);
     }

--- a/app/modules/listings/components/listing_elements.svelte
+++ b/app/modules/listings/components/listing_elements.svelte
@@ -172,7 +172,7 @@
     }
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .entities-listing-section{
       padding: 0;
     }

--- a/app/modules/listings/components/listing_info_box.svelte
+++ b/app/modules/listings/components/listing_info_box.svelte
@@ -147,7 +147,7 @@
     text-align: end;
   }
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .listing-info{
       padding: 0.5em;
       margin: 1em 0;
@@ -157,7 +157,7 @@
     }
   }
   /* Smaller screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .first-row{
       @include display-flex(column-reverse);
     }

--- a/app/modules/listings/components/listing_li.svelte
+++ b/app/modules/listings/components/listing_li.svelte
@@ -134,7 +134,7 @@
     @include sans-serif;
   }
   /* Smaller screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     li{
       width: 100%;
     }

--- a/app/modules/search/components/search_alternatives.svelte
+++ b/app/modules/search/components/search_alternatives.svelte
@@ -65,7 +65,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .alternatives{
       background-color: white;
     }

--- a/app/modules/search/components/search_controls.svelte
+++ b/app/modules/search/components/search_controls.svelte
@@ -84,7 +84,7 @@
   }
 
   /* Smaller screens */
-  @media screen and (max-width: $small-screen){
+  @media screen and (max-width: $below-small-screen){
     .searchSettingsTogglerWrapper{
       margin-top: auto;
       @include display-flex(row, center, center);

--- a/app/modules/shelves/components/shelf_box.svelte
+++ b/app/modules/shelves/components/shelf_box.svelte
@@ -158,7 +158,7 @@
     color: $grey;
   }
   /* Smaller screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .shelf-box{
       @include display-flex(column, center, center);
     }

--- a/app/modules/shelves/components/shelf_editor.svelte
+++ b/app/modules/shelves/components/shelf_editor.svelte
@@ -156,7 +156,7 @@
     @include dangerous-action;
   }
   /* Small screens */
-  @media screen and (max-width: $very-small-screen){
+  @media screen and (max-width: $below-very-small-screen){
     .shelf-editor{
       label, :global(fieldset){
         padding: 0 0.5em;

--- a/app/modules/shelves/components/shelves_section.svelte
+++ b/app/modules/shelves/components/shelves_section.svelte
@@ -92,7 +92,7 @@
     @include display-flex(row, center, space-between);
   }
   /* Smaller screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .toggle-button{
       padding: 1em 0.5em 1em 1em;
     }

--- a/app/modules/shelves/scss/shelf_items_adder.scss
+++ b/app/modules/shelves/scss/shelf_items_adder.scss
@@ -31,7 +31,7 @@
     }
   }
   /*Very Small screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     .shelf-items-candidate{
       @include display-flex(column, center, center);
     }

--- a/app/modules/tasks/scss/tasks_layout.scss
+++ b/app/modules/tasks/scss/tasks_layout.scss
@@ -25,7 +25,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .controls{
       .button{
         text-align: center;

--- a/app/modules/transactions/scss/_actions.scss
+++ b/app/modules/transactions/scss/_actions.scss
@@ -17,7 +17,7 @@
     cursor: default;
   }
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     @include display-flex(column, center, stretch);
     .action{
       width: 100%;

--- a/app/modules/transactions/scss/_header.scss
+++ b/app/modules/transactions/scss/_header.scss
@@ -27,7 +27,7 @@
     display: none;
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     padding: 1em;
     @include display-flex(row, center, space-around, wrap);
     .context{

--- a/app/modules/transactions/scss/_message.scss
+++ b/app/modules/transactions/scss/_message.scss
@@ -26,7 +26,7 @@
       max-width: 100%;
     }
     /*Small screens*/
-    @media screen and (max-width: $very-small-screen) {
+    @media screen and (max-width: $below-very-small-screen) {
       flex-direction: column;
       .message-text{
         padding-bottom: 0.5em;

--- a/app/modules/transactions/scss/_timeline.scss
+++ b/app/modules/transactions/scss/_timeline.scss
@@ -3,7 +3,7 @@
   @import './action';
   @import './message';
   /*Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     padding-left: 0.4em;
     padding-right: 0.2em;
     max-width: 100%;

--- a/app/modules/transactions/scss/focused_transaction_layout.scss
+++ b/app/modules/transactions/scss/focused_transaction_layout.scss
@@ -34,7 +34,7 @@
     @include radius;
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
   }
   /*Large screens*/
   @media screen and (min-width: $small-screen) {

--- a/app/modules/transactions/scss/transactions_layout.scss
+++ b/app/modules/transactions/scss/transactions_layout.scss
@@ -19,7 +19,7 @@ $transaction-list-width: 20em;
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     #list{
       margin-bottom: 1em;
     }

--- a/app/modules/user/scss/_login.scss
+++ b/app/modules/user/scss/_login.scss
@@ -21,7 +21,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     label{
       .complement{
         margin-left: 0.2em;

--- a/app/modules/user/scss/_password_input.scss
+++ b/app/modules/user/scss/_password_input.scss
@@ -46,7 +46,7 @@
 }
 
 /*Very Small screens*/
-@media screen and (max-width: $very-small-screen) {
+@media screen and (max-width: $below-very-small-screen) {
   #password{
     margin-bottom: 0;
   }

--- a/app/modules/user/scss/auth_menu.scss
+++ b/app/modules/user/scss/auth_menu.scss
@@ -36,7 +36,7 @@
   }
 
   /*Very Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     .otherOptions{
       flex-direction: column;
       a{
@@ -46,7 +46,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     .custom-cell{
       padding: 1em;
       text-align: center;

--- a/app/modules/users/components/user_profile.svelte
+++ b/app/modules/users/components/user_profile.svelte
@@ -107,7 +107,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .user-profile{
       @include display-flex(column, center, center);
     }

--- a/app/modules/users/components/user_profile_buttons.svelte
+++ b/app/modules/users/components/user_profile_buttons.svelte
@@ -189,7 +189,7 @@
   }
 
   /* Small screens */
-  @media screen and (max-width: $smaller-screen){
+  @media screen and (max-width: $below-smaller-screen){
     .profile-buttons{
       margin-bottom: 0.5em;
       flex-direction: column;

--- a/app/modules/users/scss/_group_profile.scss
+++ b/app/modules/users/scss/_group_profile.scss
@@ -83,7 +83,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     @include display-flex(column, stretch, center);
     .stats{
       display: none;

--- a/app/modules/users/scss/_network_users_nav.scss
+++ b/app/modules/users/scss/_network_users_nav.scss
@@ -33,7 +33,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .list-label{
       margin-bottom: 0.5em;
       font-size: 1.2em;
@@ -52,7 +52,7 @@
   }
 
   /*Very Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     .buttons{
       flex-direction: column;
       a{

--- a/app/modules/users/scss/_public_users_nav.scss
+++ b/app/modules/users/scss/_public_users_nav.scss
@@ -14,7 +14,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .lists{
       flex-direction: column;
     }

--- a/app/modules/users/scss/_users_home_nav.scss
+++ b/app/modules/users/scss/_users_home_nav.scss
@@ -33,7 +33,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     #tabs{
       margin-top: 0.5em;
     }

--- a/app/modules/users/scss/_users_home_nav_lists.scss
+++ b/app/modules/users/scss/_users_home_nav_lists.scss
@@ -41,7 +41,7 @@ $nav-avatar-size: 5em;
     padding: 0 0.2em;
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     ul{
       justify-content: center;
     }

--- a/app/modules/users/scss/_users_home_section_navs.scss
+++ b/app/modules/users/scss/_users_home_section_navs.scss
@@ -18,7 +18,7 @@ $map-large-screen-heigth: 70vh;
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     .lists{
       flex-direction: column;
     }

--- a/app/modules/users/scss/contribution.scss
+++ b/app/modules/users/scss/contribution.scss
@@ -128,7 +128,7 @@
   }
 
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     max-width: 98vw;
     .handle{
       margin: 0.5em 0;
@@ -140,7 +140,7 @@
   }
 
   /*Smaller screens*/
-  @media screen and (max-width: $smaller-screen) {
+  @media screen and (max-width: $below-smaller-screen) {
     .summary{
       min-width: 60vw;
       margin-right: auto;

--- a/app/modules/users/scss/user_li.scss
+++ b/app/modules/users/scss/user_li.scss
@@ -57,7 +57,7 @@ $user-bg: #ddd;
     }
   }
   /*Small screens*/
-  @media screen and (max-width: $small-screen) {
+  @media screen and (max-width: $below-small-screen) {
     width: 100%;
     .right-box{
       width: 100%;
@@ -95,7 +95,7 @@ $user-bg: #ddd;
     }
   }
   /*Very Small screens*/
-  @media screen and (max-width: $very-small-screen) {
+  @media screen and (max-width: $below-very-small-screen) {
     &.group-context{
       .request-actions{
         .action{


### PR DESCRIPTION
to avoid having both rules below and above the threshold to apply at the same time.

max-width and min-width are inclusive comparators (<= and >=), there is unforunately no strict comparators (< and >). An other work around would be with the `not` operator, but that makes queries more verbose and less readeable See https://stackoverflow.com/questions/48601618/strict-inequality-in-css-media-queries

PR extracted from #353, see previous discussion https://github.com/inventaire/inventaire-client/pull/353#pullrequestreview-1196531252