### PR TITLE
Hide spinner when 100 results are displayed

### DIFF
--- a/app/modules/search/components/global_search_bar.svelte
+++ b/app/modules/search/components/global_search_bar.svelte
@@ -40,6 +40,9 @@
   let showSearchControls
   let hasMore = false
 
+  // In sync with limit parameter in `server/controllers/search/search.js`
+  const resultsMaxLength = 100
+
   async function search () {
     const searchKey = `${selectedCategory}:${selectedSection}:${searchText}`
     hasMore = false
@@ -88,7 +91,8 @@
         limit: searchBatchLength,
         offset: searchOffset,
       })
-      hasMore = res.continue != null
+      hasMore = res.continue != null && res.continue < resultsMaxLength
+
       return res.results.map(serializeSubject)
     } else {
       // Increasing search limit instead of offset, as search pages aren't stable:
@@ -102,7 +106,8 @@
         search: searchText,
         limit: searchLimit,
       })
-      hasMore = res.continue != null
+      hasMore = res.continue != null && res.continue < resultsMaxLength
+
       return res.results
     }
   }

--- a/app/modules/search/components/global_search_bar.svelte
+++ b/app/modules/search/components/global_search_bar.svelte
@@ -284,7 +284,7 @@
       />
       {#if showResults}
         {#if results.length > 0}
-          <div class="results">
+          <div class="search-results">
             <ul bind:this={searchResultsEl}>
               {#each results as result, index (result.id)}
                 <SearchResult
@@ -402,7 +402,7 @@
     // The #topBar gives it a positive z-index, and it sould be displayed just below
     z-index: -1;
   }
-  .loader, .results, .no-result{
+  .loader, .search-results, .no-result{
     background-color: #eee;
   }
   .loader, .no-result{
@@ -418,7 +418,7 @@
 
   /* Medium to Large screens */
   @media screen and (min-width: $small-screen){
-    .results{
+    .search-results{
       max-height: 60vh;
       overflow: auto;
     }
@@ -442,7 +442,7 @@
       @include display-flex(column);
       overflow: hidden;
     }
-    .results, .no-result, .loader{
+    .search-results, .no-result, .loader{
       order: -1;
       flex: 1 0 0;
       overflow: auto;


### PR DESCRIPTION
Since its the maximum displayable. 
This will not give the false impression that more results will be displayed if the user waits.

This is a quick fix based on the fact that the server is not displaying more than [100 results](https://github.com/inventaire/inventaire/blob/master/server/controllers/search/search.js#L18).