### PR TITLE
add missing images: update validation on an images object

### DIFF
--- a/app/modules/entities/lib/entities.js
+++ b/app/modules/entities/lib/entities.js
@@ -208,9 +208,12 @@ export async function getEntityImage (uri) {
   const images = getEntitiesImages(uri)
   return images[uri]
 }
-
 export async function getEntitiesImagesUrls (uris) {
   const images = await getEntitiesImages(uris)
+  return extractImagesUrls(images)
+}
+
+export function extractImagesUrls (images) {
   const imageUrls = Object.values(images).map(entityImages => {
     const firstImage = getBestLangValue(app.user.lang, null, entityImages).value
     if (firstImage) return getEntityImagePath(firstImage)

--- a/app/modules/entities/lib/types/work_alt.js
+++ b/app/modules/entities/lib/types/work_alt.js
@@ -1,7 +1,7 @@
 import getBestLangValue from '../get_best_lang_value.js'
-import { getEntitiesByUris, getEntitiesImages, getEntityImage, getEntityImagePath } from '../entities.js'
+import { getEntitiesByUris, getEntitiesImages, getEntityImage, getEntityImagePath, extractImagesUrls } from '../entities.js'
 import { pluck } from 'underscore'
-import { isNonEmptyPlainObject } from '#lib/boolean_tests.js'
+import { isNonEmptyArray } from '#lib/boolean_tests'
 
 export async function addWorksImagesAndAuthors (works) {
   await Promise.all([
@@ -31,7 +31,8 @@ async function addMissingImages (entities) {
   const imagesByUri = await getEntitiesImages(uris)
   entities.forEach(entity => {
     const entityImages = imagesByUri[entity.uri]
-    if (isNonEmptyPlainObject(entityImages)) setEntityImages(entity, entityImages)
+    const imagesUrls = extractImagesUrls(entityImages)
+    if (isNonEmptyArray(imagesUrls)) setEntityImages(entity, entityImages)
   })
 }
 

--- a/app/modules/entities/lib/types/work_alt.js
+++ b/app/modules/entities/lib/types/work_alt.js
@@ -1,7 +1,6 @@
 import getBestLangValue from '../get_best_lang_value.js'
-import { getEntitiesByUris, getEntitiesImages, getEntityImage, getEntityImagePath, extractImagesUrls } from '../entities.js'
+import { getEntitiesByUris, getEntitiesImages, getEntityImage, getEntityImagePath } from '../entities.js'
 import { pluck } from 'underscore'
-import { isNonEmptyArray } from '#lib/boolean_tests'
 
 export async function addWorksImagesAndAuthors (works) {
   await Promise.all([
@@ -31,8 +30,7 @@ async function addMissingImages (entities) {
   const imagesByUri = await getEntitiesImages(uris)
   entities.forEach(entity => {
     const entityImages = imagesByUri[entity.uri]
-    const imagesUrls = extractImagesUrls(entityImages)
-    if (isNonEmptyArray(imagesUrls)) setEntityImages(entity, entityImages)
+    setEntityImages(entity, entityImages)
   })
 }
 


### PR DESCRIPTION
Necessary with server PR [#685](https://github.com/inventaire/inventaire/pull/685), as former `isNonEmptyPlainObject(entityImages)` would otherwise always be true 