### PR TITLE
sort_entities_by: add icon to hint that re-selecting the current sort mode reverts the ordering

### DIFF
--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -4,6 +4,7 @@
   import { getSortingOptionsByName } from '#entities/components/lib/works_browser_helpers'
   import { i18n } from '#user/lib/i18n'
   import { sortEntities } from '#entities/components/lib/sort_entities_by'
+  import { icon } from '#lib/handlebars_helpers/icons'
 
   export let sortingType = 'work', entities, waitingForItems
 
@@ -34,7 +35,11 @@
       {options}
       buttonLabel={i18n('Sort by')}
       on:selectSameOption={reverseOrder}
-    />
+    >
+      <div slot="selected-option-line-end">
+        {@html icon('exchange')}
+      </div>
+    </SelectDropdown>
   </div>
 {/if}
 <style lang="scss">
@@ -46,6 +51,13 @@
     }
     :global(.dropdown-content), :global(.dropdown-button){
       min-width: 10em;
+    }
+  }
+  [slot="selected-option-line-end"]{
+    :global(.fa-exchange){
+      transform: rotate(90deg);
+      margin-inline-end: 0;
+      opacity: 0.8;
     }
   }
 </style>

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -50,7 +50,10 @@
       @include display-flex(row, center, stretch);
     }
     :global(.dropdown-content), :global(.dropdown-button){
-      min-width: 10em;
+      min-width: 11em;
+    }
+    :global(.inner-select-option){
+      line-height: 1em;
     }
   }
   [slot="selected-option-line-end"]{
@@ -58,6 +61,7 @@
       transform: rotate(90deg);
       margin-inline-end: 0;
       opacity: 0.8;
+      line-height: 1rem;
     }
   }
 </style>

--- a/app/modules/general/components/select_dropdown.svelte
+++ b/app/modules/general/components/select_dropdown.svelte
@@ -91,7 +91,13 @@
               aria-selected={option.value === value}
               on:click={() => assignNewValue(option)}
             >
-              <SelectDropdownOption {option} {withImage} />
+              <SelectDropdownOption {option} {withImage}>
+                <div slot="line-end">
+                  {#if option.value === value}
+                    <slot name="selected-option-line-end" />
+                  {/if}
+                </div>
+              </SelectDropdownOption>
             </button>
           {/if}
         {/each}

--- a/app/modules/general/components/select_dropdown_option.svelte
+++ b/app/modules/general/components/select_dropdown_option.svelte
@@ -29,6 +29,8 @@
   </span>
   {#await option.promise}
     <Spinner />
+  {:then}
+    <slot name="line-end" />
   {/await}
 </div>
 


### PR DESCRIPTION
When I first gave a try to the new sort feature from #384, it was not obvious that re-selecting the current sort mode was making it reverse, so adding a hint in some form seems welcome