### PR TITLE
Entity editor: add links to properties documentation

### DIFF
--- a/app/lib/wikimedia/wikidata.js
+++ b/app/lib/wikimedia/wikidata.js
@@ -24,7 +24,7 @@ export const unprefixify = value => value?.replace(/^wdt?:/, '')
 
 export const getUriNumericId = uri => parseInt(uri.split(':')[1].substring(1))
 
-export function getWikidataPropertyUrl (uri) {
+export function getWikidataPropertyDocumentationUrl (uri) {
   const id = uri.split(':')[1]
   return `https://www.wikidata.org/wiki/Property_talk:${id}`
 }

--- a/app/lib/wikimedia/wikidata.js
+++ b/app/lib/wikimedia/wikidata.js
@@ -23,3 +23,8 @@ export function searchWikidataEntities (params) {
 export const unprefixify = value => value?.replace(/^wdt?:/, '')
 
 export const getUriNumericId = uri => parseInt(uri.split(':')[1].substring(1))
+
+export function getWikidataPropertyUrl (uri) {
+  const id = uri.split(':')[1]
+  return `https://www.wikidata.org/wiki/Property_talk:${id}`
+}

--- a/app/modules/entities/components/editor/property_claims_editor.svelte
+++ b/app/modules/entities/components/editor/property_claims_editor.svelte
@@ -124,7 +124,7 @@
     font-weight: normal;
     @include display-flex(row, center, space-between);
     &:first-child{
-      margin-block-start: 0.2em;
+      margin-block-start: 0;
     }
     &:not(:first-child){
       margin-block-start: 1em;

--- a/app/modules/entities/components/editor/property_claims_editor.svelte
+++ b/app/modules/entities/components/editor/property_claims_editor.svelte
@@ -9,7 +9,7 @@
   import { getPropertyClaimsCount, isEmptyClaimValue, isNonEmptyClaimValue } from '#entities/components/editor/lib/editors_helpers'
   import Flash from '#lib/components/flash.svelte'
   import { isWikidataPropertyUri } from '#lib/boolean_tests'
-  import { getWikidataPropertyUrl } from '#lib/wikimedia/wikidata'
+  import { getWikidataPropertyDocumentationUrl } from '#lib/wikimedia/wikidata'
 
   export let entity, property, required = false
 
@@ -73,7 +73,7 @@
       {#if isWikidataPropertyUri(property)}
         <a
           class="uri"
-          href={getWikidataPropertyUrl(property)}
+          href={getWikidataPropertyDocumentationUrl(property)}
           target="_blank"
           rel="noreferrer"
         >

--- a/app/modules/entities/components/editor/property_claims_editor.svelte
+++ b/app/modules/entities/components/editor/property_claims_editor.svelte
@@ -8,6 +8,8 @@
   import assert_ from '#lib/assert_types'
   import { getPropertyClaimsCount, isEmptyClaimValue, isNonEmptyClaimValue } from '#entities/components/editor/lib/editors_helpers'
   import Flash from '#lib/components/flash.svelte'
+  import { isWikidataPropertyUri } from '#lib/boolean_tests'
+  import { getWikidataPropertyUrl } from '#lib/wikimedia/wikidata'
 
   export let entity, property, required = false
 
@@ -68,7 +70,18 @@
     {/if}
     <div class="property-info">
       <h3 class="editor-section-header">{I18n(customLabel || property)}</h3>
-      <span class="uri">{property}</span>
+      {#if isWikidataPropertyUri(property)}
+        <a
+          class="uri"
+          href={getWikidataPropertyUrl(property)}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {property}
+        </a>
+      {:else}
+        <span class="uri">{property}</span>
+      {/if}
     </div>
     <div class="property-claim-values">
       <!-- Do not set the #each element (key) to prevent descarding claim_editor components on value change

--- a/app/modules/entities/components/editor/property_claims_editor.svelte
+++ b/app/modules/entities/components/editor/property_claims_editor.svelte
@@ -66,7 +66,10 @@
     {#if isRequiredAndMissing}
       <span class="required-notice">{I18n('required')}</span>
     {/if}
-    <h3 class="editor-section-header">{I18n(customLabel || property)}</h3>
+    <div class="property-info">
+      <h3 class="editor-section-header">{I18n(customLabel || property)}</h3>
+      <span class="uri">{property}</span>
+    </div>
     <div class="property-claim-values">
       <!-- Do not set the #each element (key) to prevent descarding claim_editor components on value change
            as that would make the "undo" impossible -->
@@ -97,6 +100,7 @@
   @import "#entities/scss/entity_editors_commons";
   .editor-section-header{
     inline-size: 9em;
+    margin-block-end: 0;
   }
   .property-claim-values{
     flex: 1 1 auto;

--- a/app/modules/entities/scss/entity_editors_commons.scss
+++ b/app/modules/entities/scss/entity_editors_commons.scss
@@ -2,8 +2,11 @@
 
 .editor-section{
   @include panel;
-  align-self: stretch;
+  align-items: stretch;
   display: flex;
+  .property-info{
+    align-self: flex-start;
+  }
   /*Large screens*/
   @media screen and (min-width: $smaller-screen) {
     margin: 0.4em 0 0.6em 0;
@@ -21,6 +24,6 @@
   @include sans-serif;
   font-weight: bold;
   margin-inline-end: 0.5em;
-  margin-block-start: 0.5em;
+  margin-block-start: 0;
   flex: 0 0 auto;
 }


### PR DESCRIPTION
It could be useful to contributors who want to learn more about properties format, constraints, data modeling considerations,  etc