### PR TITLE
entities layouts:  ease external ids links customization

### DIFF
--- a/app/lib/active_languages.ts
+++ b/app/lib/active_languages.ts
@@ -29,7 +29,7 @@ export type UserLang = typeof langs[number]
 // Generated with https://w.wiki/5cVs
 const rtlLang = new Set([ 'ace', 'ady', 'aeb', 'ar', 'arc', 'arq', 'ary', 'arz', 'az', 'bej', 'bjn', 'bm', 'bqi', 'bsk', 'ckb', 'dar', 'diq', 'dv', 'ett', 'fa', 'ff', 'glk', 'ha', 'hbo', 'he', 'jv', 'kbd', 'khw', 'kk', 'kr', 'ks', 'ku', 'kum', 'ky', 'lad', 'lki', 'lrc', 'luz', 'min', 'ms', 'mzn', 'non', 'nqo', 'ota', 'otk', 'pa', 'pnb', 'ps', 'qya', 'rif', 'sd', 'sdh', 'shi', 'shy', 'sw', 'syc', 'ta', 'tg', 'tk', 'tru', 'tzm', 'ug', 'uz', 'uzs', 'wbl', 'wo', 'xpu' ])
 
-export const getTextDirection = (lang = 'en') => {
+export function getTextDirection (lang = 'en') {
   const languageFamilyCode = lang.split('-')[0]
   return rtlLang.has(languageFamilyCode) ? 'rtl' : 'ltr'
 }

--- a/app/lib/active_languages.ts
+++ b/app/lib/active_languages.ts
@@ -29,7 +29,7 @@ export type UserLang = typeof langs[number]
 // Generated with https://w.wiki/5cVs
 const rtlLang = new Set([ 'ace', 'ady', 'aeb', 'ar', 'arc', 'arq', 'ary', 'arz', 'az', 'bej', 'bjn', 'bm', 'bqi', 'bsk', 'ckb', 'dar', 'diq', 'dv', 'ett', 'fa', 'ff', 'glk', 'ha', 'hbo', 'he', 'jv', 'kbd', 'khw', 'kk', 'kr', 'ks', 'ku', 'kum', 'ky', 'lad', 'lki', 'lrc', 'luz', 'min', 'ms', 'mzn', 'non', 'nqo', 'ota', 'otk', 'pa', 'pnb', 'ps', 'qya', 'rif', 'sd', 'sdh', 'shi', 'shy', 'sw', 'syc', 'ta', 'tg', 'tk', 'tru', 'tzm', 'ug', 'uz', 'uzs', 'wbl', 'wo', 'xpu' ])
 
-export const getTextDirection = lang => {
+export const getTextDirection = (lang = 'en') => {
   const languageFamilyCode = lang.split('-')[0]
   return rtlLang.has(languageFamilyCode) ? 'rtl' : 'ltr'
 }

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -4,6 +4,7 @@
   import { user } from '#user/user_store'
   import { I18n, i18n } from '#user/lib/i18n'
   import { icon } from '#lib/utils'
+  import { getTextDirection } from '#lib/active_languages'
 
   export let category, categoryAvailableExternalIds
 
@@ -17,7 +18,7 @@
   $: displayedCategoryExternalIds = showAllAvailableExternalIds ? categoryAvailableExternalIds : categoryPreferredAvailableExternalIds
 </script>
 
-<p class="category">
+<p class="category" dir={getTextDirection($user?.language)}>
   <span class="category-label">{I18n(categoryLabels[category])}:</span>
   {#each displayedCategoryExternalIds as { property, name, value }, i}
     <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
@@ -46,6 +47,11 @@
     :global(.fa){
       font-size: 0.8rem;
       width: 0.7rem;
+    }
+  }
+  [dir="rtl"]{
+    button :global(.fa){
+      transform: rotate(180deg);
     }
   }
 </style>

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -12,6 +12,7 @@
 
   let showAllAvailableExternalIds = false
   let showCategorySettings = false
+  const linksId = `${category}Links`
 
   let categoryPreferredAvailableExternalIds, displayedCategoryExternalIds
   $: {
@@ -24,11 +25,17 @@
 {#if categoryAvailableExternalIds.length > 0}
   <p class="category" dir={getTextDirection($user?.language)}>
     <span class="category-label">{I18n(categoryLabels[category])}:</span>
-    {#each displayedCategoryExternalIds as { property, name, value }, i}
-      <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
-    {/each}
+    <span id={linksId}>
+      {#each displayedCategoryExternalIds as { property, name, value }, i}
+        <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
+      {/each}
+    </span>
     {#if categoryPreferredAvailableExternalIds.length !== categoryAvailableExternalIds.length}
-      <button class="toggle-external-ids" on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}>
+      <button
+        class="toggle-external-ids"
+        on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}
+        aria-controls={linksId}
+      >
         {#if showAllAvailableExternalIds}
           {@html icon('chevron-left')}
           {i18n('display less')}

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -1,0 +1,51 @@
+<script>
+  import { categoryLabels } from '#entities/lib/entity_links'
+  import EntityClaimLink from '#entities/components/layouts/entity_claim_link.svelte'
+  import { user } from '#user/user_store'
+  import { I18n, i18n } from '#user/lib/i18n'
+  import { icon } from '#lib/utils'
+
+  export let category, categoryAvailableExternalIds
+
+  let showAllAvailableExternalIds = false
+
+  let categoryPreferredAvailableExternalIds, displayedCategoryExternalIds
+  $: {
+    const { customProperties = [] } = $user
+    categoryPreferredAvailableExternalIds = categoryAvailableExternalIds.filter(({ property }) => customProperties.includes(property))
+  }
+  $: displayedCategoryExternalIds = showAllAvailableExternalIds ? categoryAvailableExternalIds : categoryPreferredAvailableExternalIds
+</script>
+
+<p class="category">
+  <span class="category-label">{I18n(categoryLabels[category])}:</span>
+  {#each displayedCategoryExternalIds as { property, name, value }, i}
+    <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
+  {/each}
+  {#if categoryPreferredAvailableExternalIds.length !== categoryAvailableExternalIds.length}
+    <button on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}>
+      {#if showAllAvailableExternalIds}
+        {@html icon('chevron-left')}
+        {i18n('display less')}
+      {:else}
+        {@html icon('chevron-right')}
+        {i18n('display_x_more', { smart_count: categoryAvailableExternalIds.length - categoryPreferredAvailableExternalIds.length })}
+      {/if}
+    </button>
+  {/if}
+</p>
+
+<style lang="scss">
+  @import "#general/scss/utils";
+  .category-label{
+    color: $label-grey;
+  }
+  button{
+    margin-inline-start: 0.5em;
+    @include shy;
+    :global(.fa){
+      font-size: 0.8rem;
+      width: 0.7rem;
+    }
+  }
+</style>

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -18,23 +18,29 @@
   $: displayedCategoryExternalIds = showAllAvailableExternalIds ? categoryAvailableExternalIds : categoryPreferredAvailableExternalIds
 </script>
 
-<p class="category" dir={getTextDirection($user?.language)}>
-  <span class="category-label">{I18n(categoryLabels[category])}:</span>
-  {#each displayedCategoryExternalIds as { property, name, value }, i}
-    <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
-  {/each}
-  {#if categoryPreferredAvailableExternalIds.length !== categoryAvailableExternalIds.length}
-    <button on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}>
-      {#if showAllAvailableExternalIds}
-        {@html icon('chevron-left')}
-        {i18n('display less')}
-      {:else}
-        {@html icon('chevron-right')}
-        {i18n('display_x_more', { smart_count: categoryAvailableExternalIds.length - categoryPreferredAvailableExternalIds.length })}
-      {/if}
-    </button>
-  {/if}
-</p>
+{#if categoryAvailableExternalIds.length > 0}
+  <p class="category" dir={getTextDirection($user?.language)}>
+    <span class="category-label">{I18n(categoryLabels[category])}:</span>
+    {#each displayedCategoryExternalIds as { property, name, value }, i}
+      <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
+    {/each}
+    {#if categoryPreferredAvailableExternalIds.length !== categoryAvailableExternalIds.length}
+      <button on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}>
+        {#if showAllAvailableExternalIds}
+          {@html icon('chevron-left')}
+          {i18n('display less')}
+        {:else}
+          {@html icon('chevron-right')}
+          {#if categoryPreferredAvailableExternalIds.length === 0}
+            {i18n('display_x_links', { smart_count: categoryAvailableExternalIds.length })}
+          {:else}
+            {i18n('display_x_more', { smart_count: categoryAvailableExternalIds.length - categoryPreferredAvailableExternalIds.length })}
+          {/if}
+        {/if}
+      </button>
+    {/if}
+  </p>
+{/if}
 
 <style lang="scss">
   @import "#general/scss/utils";

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -5,10 +5,13 @@
   import { I18n, i18n } from '#user/lib/i18n'
   import { icon } from '#lib/utils'
   import { getTextDirection } from '#lib/active_languages'
+  import DisplayedLinks from '#settings/components/displayed_links.svelte'
+  import Modal from '#components/modal.svelte'
 
   export let category, categoryAvailableExternalIds
 
   let showAllAvailableExternalIds = false
+  let showCategorySettings = false
 
   let categoryPreferredAvailableExternalIds, displayedCategoryExternalIds
   $: {
@@ -25,7 +28,7 @@
       <EntityClaimLink {property} {name} {value} />{#if i !== displayedCategoryExternalIds.length - 1},&nbsp;{/if}
     {/each}
     {#if categoryPreferredAvailableExternalIds.length !== categoryAvailableExternalIds.length}
-      <button on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}>
+      <button class="toggle-external-ids" on:click={() => showAllAvailableExternalIds = !showAllAvailableExternalIds}>
         {#if showAllAvailableExternalIds}
           {@html icon('chevron-left')}
           {i18n('display less')}
@@ -39,7 +42,20 @@
         {/if}
       </button>
     {/if}
+    <button title={i18n('Customize which links should be displayed')} on:click={() => showCategorySettings = true}>
+      {@html icon('cog')}
+    </button>
   </p>
+{/if}
+
+{#if showCategorySettings}
+  <Modal on:closeModal={() => showCategorySettings = false}>
+    <div class="modal-inner">
+      <h3>{i18n('Which links would you like to see by default?')}</h3>
+      <DisplayedLinks {category} />
+      <button class="tiny-button light-blue" on:click={() => showCategorySettings = false}>{I18n('done')}</button>
+    </div>
+  </Modal>
 {/if}
 
 <style lang="scss">
@@ -47,17 +63,29 @@
   .category-label{
     color: $label-grey;
   }
-  button{
+  .toggle-external-ids{
     margin-inline-start: 0.5em;
     @include shy;
-    :global(.fa){
+    :global(.fa-chevron-left), :global(.fa-chevron-right){
       font-size: 0.8rem;
       width: 0.7rem;
     }
   }
   [dir="rtl"]{
-    button :global(.fa){
+    :global(.fa-chevron-left), :global(.fa-chevron-right){
       transform: rotate(180deg);
+    }
+  }
+  h3{
+    @include sans-serif;
+    text-align: center;
+    font-size: 1.1rem;
+  }
+  .modal-inner{
+    margin: 1em;
+    .tiny-button{
+      display: block;
+      margin: 0 auto;
     }
   }
 </style>

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -42,9 +42,11 @@
         {/if}
       </button>
     {/if}
-    <button title={i18n('Customize which links should be displayed')} on:click={() => showCategorySettings = true}>
-      {@html icon('cog')}
-    </button>
+    {#if showAllAvailableExternalIds}
+      <button title={i18n('Customize which links should be displayed')} on:click={() => showCategorySettings = true}>
+        {@html icon('cog')}
+      </button>
+    {/if}
   </p>
 {/if}
 

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { getTextDirection } from '#app/lib/active_languages'
   import { icon } from '#app/lib/icons'
   import Modal from '#components/modal.svelte'
@@ -7,8 +7,11 @@
   import DisplayedLinks from '#settings/components/displayed_links.svelte'
   import { I18n, i18n } from '#user/lib/i18n'
   import { user } from '#user/user_store'
+  import type { CategoryAvailableExternalId } from './entity_claims_links.svelte'
+  import type { PropertyCategory } from '../../lib/editor/properties_per_type'
 
-  export let category, categoryAvailableExternalIds
+  export let category: PropertyCategory
+  export let categoryAvailableExternalIds: CategoryAvailableExternalId[]
 
   let showAllAvailableExternalIds = false
   let showCategorySettings = false

--- a/app/modules/entities/components/layouts/category_external_ids.svelte
+++ b/app/modules/entities/components/layouts/category_external_ids.svelte
@@ -1,12 +1,12 @@
 <script>
-  import { categoryLabels } from '#entities/lib/entity_links'
-  import EntityClaimLink from '#entities/components/layouts/entity_claim_link.svelte'
-  import { user } from '#user/user_store'
-  import { I18n, i18n } from '#user/lib/i18n'
-  import { icon } from '#lib/utils'
-  import { getTextDirection } from '#lib/active_languages'
-  import DisplayedLinks from '#settings/components/displayed_links.svelte'
+  import { getTextDirection } from '#app/lib/active_languages'
+  import { icon } from '#app/lib/icons'
   import Modal from '#components/modal.svelte'
+  import EntityClaimLink from '#entities/components/layouts/entity_claim_link.svelte'
+  import { categoryLabels } from '#entities/lib/entity_links'
+  import DisplayedLinks from '#settings/components/displayed_links.svelte'
+  import { I18n, i18n } from '#user/lib/i18n'
+  import { user } from '#user/user_store'
 
   export let category, categoryAvailableExternalIds
 

--- a/app/modules/entities/components/layouts/entity_claims_links.svelte
+++ b/app/modules/entities/components/layouts/entity_claims_links.svelte
@@ -1,5 +1,15 @@
+<script context="module" lang="ts">
+  import type { DisplayConfig } from '#entities/lib/entity_links'
+  import type { InvClaimValue } from '#server/types/entity'
+  import type { PropertyCategory } from '../../lib/editor/properties_per_type'
+
+  export type CategoryAvailableExternalId = DisplayConfig & { value: InvClaimValue }
+  export type AvailableExternalIdsByCategory = Record<PropertyCategory, CategoryAvailableExternalId[]>
+</script>
+
 <script lang="ts">
   import { keys, pick, values } from 'underscore'
+  import { objectEntries } from '#app/lib/utils'
   import CategoryExternalIds from '#entities/components/layouts/category_external_ids.svelte'
   import { externalIdsDisplayConfigs } from '#entities/lib/entity_links'
   import type { Claims } from '#server/types/entity'
@@ -7,16 +17,17 @@
   export let claims: Claims
 
   const availableExternalIds = pick(externalIdsDisplayConfigs, keys(claims))
-  const availableExternalIdsByCategory = {}
+  const _availableExternalIdsByCategory = {}
   for (const propertyData of values(availableExternalIds)) {
     const { property, category } = propertyData
-    availableExternalIdsByCategory[category] = availableExternalIdsByCategory[category] || []
-    availableExternalIdsByCategory[category].push({ ...propertyData, value: claims[property][0] })
+    _availableExternalIdsByCategory[category] = _availableExternalIdsByCategory[category] || []
+    _availableExternalIdsByCategory[category].push({ ...propertyData, value: claims[property][0] })
   }
+  const availableExternalIdsByCategory = _availableExternalIdsByCategory as AvailableExternalIdsByCategory
 </script>
 
 <div class="entity-claims-links">
-  {#each Object.entries(availableExternalIdsByCategory) as [ category, categoryAvailableExternalIds ]}
+  {#each objectEntries(availableExternalIdsByCategory) as [ category, categoryAvailableExternalIds ]}
     <CategoryExternalIds {category} {categoryAvailableExternalIds} />
   {/each}
 </div>

--- a/app/modules/entities/components/layouts/entity_claims_links.svelte
+++ b/app/modules/entities/components/layouts/entity_claims_links.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-  import { pick } from 'underscore'
+  import { keys, pick, values } from 'underscore'
   import CategoryExternalIds from '#entities/components/layouts/category_external_ids.svelte'
   import { externalIdsDisplayConfigs } from '#entities/lib/entity_links'
+  import type { Claims } from '#server/types/entity'
 
-  export let claims
+  export let claims: Claims
 
-  const availableExternalIds = pick(externalIdsDisplayConfigs, Object.keys(claims))
+  const availableExternalIds = pick(externalIdsDisplayConfigs, keys(claims))
   const availableExternalIdsByCategory = {}
-  for (const propertyData of Object.values(availableExternalIds)) {
+  for (const propertyData of values(availableExternalIds)) {
     const { property, category } = propertyData
     availableExternalIdsByCategory[category] = availableExternalIdsByCategory[category] || []
     availableExternalIdsByCategory[category].push({ ...propertyData, value: claims[property][0] })

--- a/app/modules/entities/components/layouts/entity_claims_links.svelte
+++ b/app/modules/entities/components/layouts/entity_claims_links.svelte
@@ -1,44 +1,21 @@
 <script lang="ts">
-  import { objectEntries } from '#app/lib/utils'
-  import EntityClaimLink from '#entities/components/layouts/entity_claim_link.svelte'
-  import type { PropertyCategory } from '#entities/lib/editor/properties_per_type'
-  import { categoryLabels, getDisplayedPropertiesByCategory, type DisplayConfig } from '#entities/lib/entity_links'
-  import type { InvClaimValue } from '#server/types/entity'
-  import { I18n } from '#user/lib/i18n'
+  import { pick } from 'underscore'
+  import CategoryExternalIds from '#entities/components/layouts/category_external_ids.svelte'
+  import { externalIdsDisplayConfigs } from '#entities/lib/entity_links'
 
   export let claims
 
-  type CustomDisplayConfig = DisplayConfig & { value?: InvClaimValue }
-  const categories: Partial<Record<PropertyCategory, CustomDisplayConfig[]>> = {}
-
-  const displayedPropertiesByCategory = getDisplayedPropertiesByCategory()
-  for (const [ category, propertiesData ] of objectEntries(displayedPropertiesByCategory)) {
-    categories[category] = []
-    for (const propertyData of propertiesData) {
-      const { property } = propertyData
-      if (claims[property]?.[0] != null) {
-        categories[category].push({ ...propertyData, value: claims[property][0] })
-      }
-    }
+  const availableExternalIds = pick(externalIdsDisplayConfigs, Object.keys(claims))
+  const availableExternalIdsByCategory = {}
+  for (const propertyData of Object.values(availableExternalIds)) {
+    const { property, category } = propertyData
+    availableExternalIdsByCategory[category] = availableExternalIdsByCategory[category] || []
+    availableExternalIdsByCategory[category].push({ ...propertyData, value: claims[property][0] })
   }
 </script>
 
 <div class="entity-claims-links">
-  {#each Object.entries(categories) as [ category, propertiesData ]}
-    {#if propertiesData.length > 0}
-      <p class="category">
-        <span class="category-label">{I18n(categoryLabels[category])}:</span>
-        {#each propertiesData as { property, name, value }, i}
-          <EntityClaimLink {property} {name} {value} />{#if i !== propertiesData.length - 1},&nbsp;{/if}
-        {/each}
-      </p>
-    {/if}
+  {#each Object.entries(availableExternalIdsByCategory) as [ category, categoryAvailableExternalIds ]}
+    <CategoryExternalIds {category} {categoryAvailableExternalIds} />
   {/each}
 </div>
-
-<style lang="scss">
-  @import "#general/scss/utils";
-  .category-label{
-    color: $label-grey;
-  }
-</style>

--- a/app/modules/entities/lib/entity_links.ts
+++ b/app/modules/entities/lib/entity_links.ts
@@ -366,19 +366,6 @@ for (const category of Object.keys(websitesByCategoryAndName)) {
   websitesByCategoryAndName[category] = sortObjectKeys(websitesByCategoryAndName[category], sortAlphabetically)
 }
 
-export type DisplayedPropertiesByCategory = Partial<Record<PropertyCategory, DisplayConfig[]>>
-
-export function getDisplayedPropertiesByCategory () {
-  const customProperties: User['customProperties'] = app.user.get('customProperties') || []
-  if (isNonEmptyArray(customProperties)) {
-    const displayedProperties = pick(externalIdsDisplayConfigs, customProperties)
-    const displayedPropertiesByCategory: DisplayedPropertiesByCategory = groupBy(Object.values(displayedProperties), 'category')
-    return displayedPropertiesByCategory
-  } else {
-    return {}
-  }
-}
-
 export const categoryLabels = {
   bibliographicDatabases: 'bibliographic databases',
   socialNetworks: 'social networks',

--- a/app/modules/entities/lib/entity_links.ts
+++ b/app/modules/entities/lib/entity_links.ts
@@ -1,11 +1,8 @@
-import { compact, groupBy, pick, pluck, uniq } from 'underscore'
-import app from '#app/app'
-import { isNonEmptyArray } from '#app/lib/boolean_tests'
+import { compact, pluck, uniq } from 'underscore'
 import { objectEntries, sortObjectKeys } from '#app/lib/utils'
 import { getUriNumericId } from '#app/lib/wikimedia/wikidata'
 import type { Url } from '#server/types/common'
 import type { PropertyUri } from '#server/types/entity'
-import type { User } from '#server/types/user'
 import type { PropertyCategory } from './editor/properties_per_type'
 
 type WebsiteName = string

--- a/app/modules/settings/components/displayed_links.svelte
+++ b/app/modules/settings/components/displayed_links.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { debounce } from 'underscore'
+  import { debounce, difference, intersection, uniq } from 'underscore'
   import app from '#app/app'
   import Flash from '#app/lib/components/flash.svelte'
   import { onChange } from '#app/lib/svelte/svelte'
@@ -7,6 +7,12 @@
   import { I18n } from '#user/lib/i18n'
 
   const { bibliographicDatabases, socialNetworks } = websitesByCategoryAndName
+
+  const bibliographicDatabasesNames = Object.keys(bibliographicDatabases)
+  const socialNetworksNames = Object.keys(socialNetworks)
+
+  let selectedBibliographicDatabasesCount = 0
+  let selectedSocialNetworksCount = 0
 
   let customProperties = app.user.get('customProperties') || []
   let stringifiedSavedCustomProperties = JSON.stringify(customProperties)
@@ -35,45 +41,83 @@
   const lazyUpdate = debounce(updateCustomProperties, 1000)
   function onSelectionChange () {
     customProperties = getPropertiesFromWebsitesNames(selectedWebsites)
+    selectedBibliographicDatabasesCount = intersection(bibliographicDatabasesNames, selectedWebsites).length
+    selectedSocialNetworksCount = intersection(socialNetworksNames, selectedWebsites).length
     lazyUpdate()
   }
   $: onChange(selectedWebsites, onSelectionChange)
+
+  function toggleAllSection ({ names, selectedCount }) {
+    if (selectedCount !== names.length) {
+      selectedWebsites = uniq(selectedWebsites.concat(names))
+    } else {
+      selectedWebsites = difference(selectedWebsites, names)
+    }
+  }
 </script>
 
-<fieldset>
-  <legend>{I18n('bibliographic databases')}</legend>
-  {#each Object.keys(bibliographicDatabases) as websiteName}
-    <label>
-      <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
-      {websiteName}
-    </label>
-  {/each}
-</fieldset>
-<fieldset>
-  <legend>{I18n('social networks')}</legend>
-  {#each Object.keys(socialNetworks) as websiteName}
-    <label>
-      <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
-      {websiteName}
-    </label>
-  {/each}
-</fieldset>
+<section>
+  <label class="category">
+    <input
+      type="checkbox"
+      checked={selectedBibliographicDatabasesCount === bibliographicDatabasesNames.length}
+      indeterminate={selectedBibliographicDatabasesCount !== 0 && selectedBibliographicDatabasesCount !== bibliographicDatabasesNames.length}
+      on:click={() => toggleAllSection({ names: bibliographicDatabasesNames, selectedCount: selectedBibliographicDatabasesCount })}
+    />
+    {I18n('bibliographic databases')}
+  </label>
+  <fieldset>
+    {#each bibliographicDatabasesNames as websiteName}
+      <label>
+        <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
+        {websiteName}
+      </label>
+    {/each}
+  </fieldset>
+</section>
+
+<section>
+  <label class="category">
+    <input
+      type="checkbox"
+      checked={selectedSocialNetworksCount === socialNetworksNames.length}
+      indeterminate={selectedSocialNetworksCount !== 0 && selectedSocialNetworksCount !== socialNetworksNames.length}
+      on:click={() => toggleAllSection({ names: socialNetworksNames, selectedCount: selectedSocialNetworksCount })}
+    />
+    {I18n('social networks')}
+  </label>
+  <fieldset>
+    {#each socialNetworksNames as websiteName}
+      <label>
+        <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
+        {websiteName}
+      </label>
+    {/each}
+  </fieldset>
+</section>
+
 <Flash bind:state={flash} />
 
 <style lang="scss">
   @import "#general/scss/utils";
+  section{
+    margin-block-end: 1em;
+    @include shy-border;
+    @include radius;
+  }
   fieldset{
     @include display-flex(row, null, null, wrap);
-    margin-block-start: 0.5em;
   }
-  legend{
+  .category{
     font-weight: bold;
+    font-size: 1rem;
+    padding: 0.5em;
+    background-color: $lighter-grey;
   }
-  label{
+  label:not(.category){
+    font-size: 1rem;
+    @include display-flex(row, center);
     width: min(15em, 80vw);
     padding: 0.5em;
-    font-size: 1rem;
-    cursor: pointer;
-    @include display-flex(row, center);
   }
 </style>

--- a/app/modules/settings/components/displayed_links.svelte
+++ b/app/modules/settings/components/displayed_links.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { debounce, difference, intersection, uniq } from 'underscore'
+  import { debounce, difference, intersection, keys, uniq } from 'underscore'
   import app from '#app/app'
   import Flash from '#app/lib/components/flash.svelte'
   import { onChange } from '#app/lib/svelte/svelte'
@@ -10,8 +10,8 @@
 
   const { bibliographicDatabases, socialNetworks } = websitesByCategoryAndName
 
-  const bibliographicDatabasesNames = Object.keys(bibliographicDatabases)
-  const socialNetworksNames = Object.keys(socialNetworks)
+  const bibliographicDatabasesNames = keys(bibliographicDatabases)
+  const socialNetworksNames = keys(socialNetworks)
 
   let selectedBibliographicDatabasesCount = 0
   let selectedSocialNetworksCount = 0

--- a/app/modules/settings/components/displayed_links.svelte
+++ b/app/modules/settings/components/displayed_links.svelte
@@ -6,6 +6,8 @@
   import { getPropertiesFromWebsitesNames, getWebsitesNamesFromProperties, websitesByCategoryAndName } from '#entities/lib/entity_links'
   import { I18n } from '#user/lib/i18n'
 
+  export let category = null
+
   const { bibliographicDatabases, socialNetworks } = websitesByCategoryAndName
 
   const bibliographicDatabasesNames = Object.keys(bibliographicDatabases)
@@ -56,45 +58,49 @@
   }
 </script>
 
-<section>
-  <label class="category">
-    <input
-      type="checkbox"
-      checked={selectedBibliographicDatabasesCount === bibliographicDatabasesNames.length}
-      indeterminate={selectedBibliographicDatabasesCount !== 0 && selectedBibliographicDatabasesCount !== bibliographicDatabasesNames.length}
-      on:click={() => toggleAllSection({ names: bibliographicDatabasesNames, selectedCount: selectedBibliographicDatabasesCount })}
-    />
-    {I18n('bibliographic databases')}
-  </label>
-  <fieldset>
-    {#each bibliographicDatabasesNames as websiteName}
-      <label>
-        <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
-        {websiteName}
-      </label>
-    {/each}
-  </fieldset>
-</section>
+{#if category == null || category === 'bibliographicDatabases'}
+  <section>
+    <label class="category">
+      <input
+        type="checkbox"
+        checked={selectedBibliographicDatabasesCount === bibliographicDatabasesNames.length}
+        indeterminate={selectedBibliographicDatabasesCount !== 0 && selectedBibliographicDatabasesCount !== bibliographicDatabasesNames.length}
+        on:click={() => toggleAllSection({ names: bibliographicDatabasesNames, selectedCount: selectedBibliographicDatabasesCount })}
+      />
+      {I18n('bibliographic databases')}
+    </label>
+    <fieldset>
+      {#each bibliographicDatabasesNames as websiteName}
+        <label>
+          <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
+          {websiteName}
+        </label>
+      {/each}
+    </fieldset>
+  </section>
+{/if}
 
-<section>
-  <label class="category">
-    <input
-      type="checkbox"
-      checked={selectedSocialNetworksCount === socialNetworksNames.length}
-      indeterminate={selectedSocialNetworksCount !== 0 && selectedSocialNetworksCount !== socialNetworksNames.length}
-      on:click={() => toggleAllSection({ names: socialNetworksNames, selectedCount: selectedSocialNetworksCount })}
-    />
-    {I18n('social networks')}
-  </label>
-  <fieldset>
-    {#each socialNetworksNames as websiteName}
-      <label>
-        <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
-        {websiteName}
-      </label>
-    {/each}
-  </fieldset>
-</section>
+{#if category == null || category === 'socialNetworks'}
+  <section>
+    <label class="category">
+      <input
+        type="checkbox"
+        checked={selectedSocialNetworksCount === socialNetworksNames.length}
+        indeterminate={selectedSocialNetworksCount !== 0 && selectedSocialNetworksCount !== socialNetworksNames.length}
+        on:click={() => toggleAllSection({ names: socialNetworksNames, selectedCount: selectedSocialNetworksCount })}
+      />
+      {I18n('social networks')}
+    </label>
+    <fieldset>
+      {#each socialNetworksNames as websiteName}
+        <label>
+          <input type="checkbox" bind:group={selectedWebsites} value={websiteName} />
+          {websiteName}
+        </label>
+      {/each}
+    </fieldset>
+  </section>
+{/if}
 
 <Flash bind:state={flash} />
 
@@ -106,7 +112,7 @@
     @include radius;
   }
   fieldset{
-    @include display-flex(row, null, null, wrap);
+    columns: 15rem auto;
   }
   .category{
     font-weight: bold;
@@ -117,7 +123,6 @@
   label:not(.category){
     font-size: 1rem;
     @include display-flex(row, center);
-    width: min(15em, 80vw);
     padding: 0.5em;
   }
 </style>


### PR DESCRIPTION
As we now have plenty of links from external ids to display, having good interfaces to customize what should be displayed seems important. In particular, a user that doesn't explore the settings might not realize that they can display all those links.