### PR TITLE
Article table view

### DIFF
--- a/app/modules/entities/components/layouts/article.svelte
+++ b/app/modules/entities/components/layouts/article.svelte
@@ -1,11 +1,11 @@
 <script>
+  import EntityTitle from './entity_title.svelte'
   import { i18n } from '#user/lib/i18n'
   import BaseLayout from './base_layout.svelte'
   import AuthorsInfo from './authors_info.svelte'
   import Infobox from './infobox.svelte'
   import { omitNonInfoboxClaims } from '#entities/components/lib/work_helpers'
   import Link from '#lib/components/link.svelte'
-  import getBestLangValue from '#entities/lib/get_best_lang_value'
   import Spinner from '#general/components/spinner.svelte'
   import WorksBrowser from '#entities/components/layouts/works_browser.svelte'
   import { getSubEntitiesSections } from '#entities/components/lib/entities'
@@ -15,9 +15,7 @@
 
   export let entity
 
-  const { uri, claims, wikisource, originalLang, description, label, labelLang } = entity
-
-  const descriptionLang = getBestLangValue(app.user.lang, originalLang, description)
+  const { uri, claims, wikisource } = entity
 
   setContext('layout-context', 'article')
 
@@ -44,20 +42,7 @@
   <div class="entity-layout" slot="entity">
     <div class="top-section">
       <div class="work-section">
-        <h4 lang={labelLang}>
-          {#if href}
-            <Link
-              url={href}
-              text={label}
-              icon="link"
-            />
-          {:else}
-            {label}
-          {/if}
-        </h4>
-        {#if description}
-          <p class="description grey" lang={descriptionLang}>{description}</p>
-        {/if}
+        <EntityTitle {entity} hasLinkTitle={href} {href} />
         <AuthorsInfo {claims} />
         <Infobox
           claims={omitNonInfoboxClaims(entity.claims)}

--- a/app/modules/entities/components/layouts/base_layout.svelte
+++ b/app/modules/entities/components/layouts/base_layout.svelte
@@ -49,7 +49,6 @@
     @include display-flex(column, stretch, center);
     margin: 0 auto;
     max-inline-size: 84em;
-    padding: 0 1em;
     background-color: white;
   }
   .typeLabel{
@@ -73,12 +72,18 @@
   }
   /* Large screens */
   @media screen and (min-width: $small-screen){
+    .layout{
+      padding: 0 1em;
+    }
     .header-wrapper{
       margin-inline-start: 1.2em;
     }
   }
   /* Small screens */
   @media screen and (max-width: $small-screen){
+    .layout{
+      padding: 0 0.5em;
+    }
     .header-wrapper{
       @include display-flex(row, center, space-between);
     }

--- a/app/modules/entities/components/layouts/claim_infobox.svelte
+++ b/app/modules/entities/components/layouts/claim_infobox.svelte
@@ -8,7 +8,7 @@
   export let prop
   export let values
   export let omitLabel = false
-  export let entitiesByUris
+  export let entitiesByUris = {}
   export let entityType
 
   let propertyLabelI18nKey = prop

--- a/app/modules/entities/components/layouts/entity_list_compact.svelte
+++ b/app/modules/entities/components/layouts/entity_list_compact.svelte
@@ -1,0 +1,52 @@
+<script>
+  import Link from '#lib/components/link.svelte'
+  import ClaimInfobox from './claim_infobox.svelte'
+
+  export let entity, relatedEntities
+
+  let { claims, subtitle, pathname } = entity
+</script>
+<div class="entity-list-compact">
+  <div class="date">
+    <ClaimInfobox
+      values={claims['wdt:P577']}
+      prop="wdt:P577"
+      omitLabel={true}
+    />
+  </div>
+
+  <div class="title">
+    <Link
+      url={pathname}
+      text={claims['wdt:P1476']}
+      dark={true}
+    />
+    {#if subtitle}
+      <span class="subtitle">{subtitle}</span>
+    {/if}
+  </div>
+  <!-- TODO: display publisher by fetching more related entities
+  (see function fetchRelatedEntities)
+  {#if $screen.isLargerThan('$small-screen')}
+    <div class="publisher">
+      <ClaimInfobox
+        values={claims['wdt:P123']}
+        prop="wdt:P123"
+        omitLabel={true}
+      />
+    </div>
+  {/if}
+  -->
+  <div class="authors">
+    <ClaimInfobox
+      values={claims['wdt:P50']}
+      prop="wdt:P50"
+      omitLabel={true}
+      entitiesByUris={relatedEntities}
+    />
+  </div>
+</div>
+<style lang="scss">
+  @import "#general/scss/utils";
+  @import "#entities/scss/entity_list_compact";
+</style>

--- a/app/modules/entities/components/layouts/entity_list_compact_title_row.svelte
+++ b/app/modules/entities/components/layouts/entity_list_compact_title_row.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { I18n } from '#user/lib/i18n'
+</script>
+<div class="entity-list-compact">
+  <div class="date">
+    {I18n('date')}
+  </div>
+
+  <div class="title">
+    {I18n('title')}
+  </div>
+
+  <div class="authors">
+    {I18n('authors')}
+  </div>
+</div>
+<style lang="scss">
+  @import "#general/scss/utils";
+  @import "#entities/scss/entity_list_compact";
+  .entity-list-compact{
+    font-weight: bold;
+    border-block-end: 1px solid #ddd;
+    position: sticky;
+    inset-block: 0;
+  }
+</style>

--- a/app/modules/entities/components/layouts/entity_title.svelte
+++ b/app/modules/entities/components/layouts/entity_title.svelte
@@ -4,8 +4,8 @@
   import { formatYearClaim } from '#entities/components/lib/claims_helpers'
   import SourceLogo from '#inventory/components/entity_source_logo.svelte'
 
-  export let entity, sourceLogo
-  export let standalone = true
+  export let entity, sourceLogo, href
+  export let hasLinkTitle = false
 
   const { uri, claims, label } = entity
   const birthOrDeathDates = claims['wdt:P569'] || claims['wdt:P570']
@@ -13,14 +13,14 @@
   $: subtitle = claims['wdt:P1680']
 </script>
 <h2>
-  {#if standalone}
-    {label}
-  {:else}
+  {#if hasLinkTitle}
     <Link
-      url={`/entity/${uri}`}
+      url={href || `entity/${uri}`}
       text={label}
       dark={true}
     />
+  {:else}
+    {label}
   {/if}
   {#if sourceLogo}
     <SourceLogo {entity} />

--- a/app/modules/entities/components/layouts/works_browser_section.svelte
+++ b/app/modules/entities/components/layouts/works_browser_section.svelte
@@ -198,7 +198,7 @@
     @include display-flex(row, center);
   }
   .title-row{
-    @include display-flex(row, center, space-between);
+    @include display-flex(row, center, space-between, wrap);
     margin: 0.3em 0.5em;
   }
   ul{

--- a/app/modules/entities/components/layouts/works_browser_section.svelte
+++ b/app/modules/entities/components/layouts/works_browser_section.svelte
@@ -1,6 +1,8 @@
 <script>
   import Spinner from '#general/components/spinner.svelte'
   import EntityListRow from '#entities/components/layouts/entity_list_row.svelte'
+  import EntityListCompact from '#entities/components/layouts/entity_list_compact.svelte'
+  import EntityListCompactTitleRow from '#entities/components/layouts/entity_list_compact_title_row.svelte'
   import SectionLabel from '#entities/components/layouts/section_label.svelte'
   import SortEntitiesBy from '#entities/components/layouts/sort_entities_by.svelte'
   import WorkGridCard from '#entities/components/layouts/work_grid_card.svelte'
@@ -18,7 +20,7 @@
 
   export let section, displayMode, facets, facetsSelectedValues, textFilterUris
 
-  const { entities: works, searchable = true, sortingType } = section
+  const { entities: works, searchable = true, sortingType, isCompactDisplay } = section
   let { label, context } = section
 
   let filteredWorks = works
@@ -138,9 +140,21 @@
       on:scroll={onScrollToBottom(lazyDisplay)}
       bind:this={scrollableElement}
     >
+      {#if isCompactDisplay}
+        <EntityListCompactTitleRow />
+      {/if}
       {#each paginatedWorks as work (work.uri)}
-        <li animate:flip={{ duration: 300 }}>
-          {#if displayMode === 'grid'}
+        <li
+          animate:flip={{ duration: 300 }}
+          class:isCompactDisplay
+        >
+          {#if isCompactDisplay}
+            <!-- known case: article -->
+            <EntityListCompact
+              entity={work}
+              bind:relatedEntities={work.relatedEntities}
+            />
+          {:else if displayMode === 'grid'}
             <WorkGridCard {work} />
           {:else}
             <EntityListRow
@@ -206,6 +220,9 @@
   }
   li{
     @include display-flex(row, inherit, space-between);
+  }
+  .isCompactDisplay{
+    inline-size: 100%;
   }
   .no-work{
     color: $grey;

--- a/app/modules/entities/components/lib/entities.js
+++ b/app/modules/entities/components/lib/entities.js
@@ -51,7 +51,8 @@ const urisGetterByType = {
         label: I18n('articles'),
         uris: pluck(articles,
           'uri'),
-        searchable: false
+        searchable: false,
+        isCompactDisplay: true
       },
     ]
   },
@@ -98,7 +99,12 @@ const urisGetterByType = {
     const { claims } = entity
     const uris = claims['wdt:P2860']
     return [
-      { label: I18n('cites articles'), uris, searchable: false },
+      {
+        label: I18n('cites articles'),
+        uris,
+        searchable: false,
+        isCompactDisplay: true,
+      },
     ]
   },
   claim: async ({ entity, property, refresh }) => {

--- a/app/modules/entities/components/lib/entities.js
+++ b/app/modules/entities/components/lib/entities.js
@@ -52,7 +52,8 @@ const urisGetterByType = {
         uris: pluck(articles,
           'uri'),
         searchable: false,
-        isCompactDisplay: true
+        isCompactDisplay: true,
+        sortingType: 'article'
       },
     ]
   },
@@ -104,6 +105,7 @@ const urisGetterByType = {
         uris,
         searchable: false,
         isCompactDisplay: true,
+        sortingType: 'article'
       },
     ]
   },

--- a/app/modules/entities/components/lib/works_browser_helpers.js
+++ b/app/modules/entities/components/lib/works_browser_helpers.js
@@ -266,6 +266,10 @@ let sortingFunctionByNameByType = {
     byPopularity: popularityOption,
     byAlphabet: alphabeticalOption,
   },
+  article: {
+    byPublicationDate: publicationDateOption,
+    byAlphabet: alphabeticalOption,
+  }
 }
 
 export const getSortingOptionsByName = type => {

--- a/app/modules/entities/scss/_entity_list_compact.scss
+++ b/app/modules/entities/scss/_entity_list_compact.scss
@@ -6,6 +6,7 @@
   inline-size: 100%;
   .title{
     flex: 4 0 0;
+    margin: 0 0.5em;
   }
   .date{
     flex: 1 0 0;

--- a/app/modules/entities/scss/_entity_list_compact.scss
+++ b/app/modules/entities/scss/_entity_list_compact.scss
@@ -1,0 +1,19 @@
+.entity-list-compact{
+  @include display-flex(row, center);
+  background-color: white;
+  margin-block-end: 0.5em;
+  padding: 0.5em;
+  inline-size: 100%;
+  .title{
+    flex: 4 0 0;
+  }
+  .date{
+    flex: 1 0 0;
+  }
+  // .publisher{
+  //   flex: 2 0 0;
+  // }
+  .authors{
+    flex: 2 0 0;
+  }
+}

--- a/app/modules/tasks/components/task_entity.svelte
+++ b/app/modules/tasks/components/task_entity.svelte
@@ -14,7 +14,7 @@
   import AuthorsInfo from '#entities/components/layouts/authors_info.svelte'
 
   export let entity, error, matchedTitles
-  let standalone = false
+  let hasLinkTitle = true
   let subEntities
 
   const waitingForSubEntities = getAuthorWorksWithImagesAndCoauthors(entity)
@@ -33,7 +33,7 @@
       <div class="entity-title-wrapper">
         <EntityTitle
           {entity}
-          {standalone}
+          {hasLinkTitle}
           sourceLogo={true}
         />
       </div>


### PR DESCRIPTION
More compact view for articles sections (+ 2 details related to article layout)

Inspired by scholia's display:
![2024-02-05_15-57](https://github.com/inventaire/inventaire-client/assets/5363918/297a51a9-7d03-4a65-b85e-906576b4a555)

Tested entities: 
  - author layout: `entity/wd:Q63799298`, `/entity/wd:Q37638169`
  - article layout: `/entity/wd:Q104739517`

Adding columns for P123 and/or P921 (aka publisher, main subject) would require some additional section typing to fetch appropriate related entities. This may be done later, in anther PR.
