### PR TITLE
align authors display

### DIFF
--- a/app/modules/entities/components/deduplicate_controls.svelte
+++ b/app/modules/entities/components/deduplicate_controls.svelte
@@ -64,12 +64,12 @@
           class="skip"
           on:click={() => dispatch('skip')}>{I18n('skip')}
         </button>
+        <button
+          class="reset"
+          title="Shortkey: r"
+          on:click={() => dispatch('reset')}>{I18n('reset')}
+        </button>
       {/if}
-      <button
-        class="reset"
-        title="Shortkey: r"
-        on:click={() => dispatch('reset')}>{I18n('reset')}
-      </button>
     </div>
   </div>
   {#if flash}

--- a/app/modules/entities/components/layouts/article.svelte
+++ b/app/modules/entities/components/layouts/article.svelte
@@ -9,7 +9,6 @@
   import Spinner from '#general/components/spinner.svelte'
   import WorksBrowser from '#entities/components/layouts/works_browser.svelte'
   import { getSubEntitiesSections } from '#entities/components/lib/entities'
-  import { byPublicationDate } from '#entities/lib/entities'
   import { setContext } from 'svelte'
   import { debounce } from 'underscore'
   import { onChange } from '#lib/svelte/svelte'
@@ -28,7 +27,7 @@
 
   let sections, waitingForReverseEntities, flash
   function getSections () {
-    waitingForReverseEntities = getSubEntitiesSections({ entity, sortFn: byPublicationDate })
+    waitingForReverseEntities = getSubEntitiesSections({ entity })
       .then(res => sections = res)
       .catch(err => flash = err)
   }

--- a/app/modules/entities/components/layouts/author.svelte
+++ b/app/modules/entities/components/layouts/author.svelte
@@ -1,7 +1,6 @@
 <script>
   import Spinner from '#general/components/spinner.svelte'
   import { getSubEntitiesSections } from '#entities/components/lib/entities'
-  import { byPublicationDate } from '#entities/lib/entities'
   import { omitNonInfoboxClaims } from '#entities/components/lib/work_helpers'
   import BaseLayout from './base_layout.svelte'
   import Infobox from './infobox.svelte'
@@ -34,7 +33,7 @@
 
   let sections, waitingForSubEntities
   function getSections () {
-    waitingForSubEntities = getSubEntitiesSections({ entity, sortFn: byPublicationDate })
+    waitingForSubEntities = getSubEntitiesSections({ entity })
       .then(res => sections = res)
       .catch(err => flash = err)
   }

--- a/app/modules/entities/components/layouts/author.svelte
+++ b/app/modules/entities/components/layouts/author.svelte
@@ -20,7 +20,7 @@
   import { onChange } from '#lib/svelte/svelte'
   import { debounce } from 'underscore'
 
-  export let entity, standalone
+  export let entity
   let flash
 
   const { uri, type } = entity
@@ -50,7 +50,7 @@
   <div class="entity-layout" slot="entity">
     <div class="top-section">
       <div class="work-section">
-        <EntityTitle {entity} {standalone} />
+        <EntityTitle {entity} />
         <div class="infobox-and-summary">
           {#if isNonEmptyPlainObject(entity.image)}
             <EntityImage

--- a/app/modules/entities/components/layouts/author_display.svelte
+++ b/app/modules/entities/components/layouts/author_display.svelte
@@ -5,7 +5,7 @@
   import { imgSrc } from '#lib/handlebars_helpers/images'
   import getBestLangValue from '#entities/lib/get_best_lang_value'
 
-  export let entityData = {}, claimValue
+  export let entityData = {}, claimValue, hasManyClaimValues
 
   const { labels, claims = {}, uri, image = {} } = entityData
   let url, label
@@ -23,6 +23,7 @@
   href={url}
   title={label}
   on:click={loadInternalLink}
+  class:hasManyClaimValues
 >
   {#if image.url}
     <img src={imgSrc(image.url, 56)} alt={i18n('author picture')} loading="lazy" />
@@ -53,6 +54,9 @@
       opacity: 0.8;
       cursor: pointer;
     }
+  }
+  .hasManyClaimValues{
+    inline-size: 15em;
   }
   .author-info{
     padding: 0 1em;

--- a/app/modules/entities/components/layouts/authors_info_role.svelte
+++ b/app/modules/entities/components/layouts/authors_info_role.svelte
@@ -14,10 +14,12 @@
     <div class="authors">
       {#each roleProperties as prop}
         {#if claims[prop]}
+          { @const hasManyClaimValues = claims[prop].length > 15}
           {#each claims[prop] as claimValue}
             <AuthorDisplay
               entityData={authorsByUris[claimValue]}
               {claimValue}
+              {hasManyClaimValues}
             />
           {/each}
         {/if}
@@ -32,7 +34,7 @@
     @include display-flex(column, flex-start, flex-start, wrap);
   }
   .authors{
-    @include display-flex(row, flex-end, flex-start, wrap);
+    @include display-flex(row, center, flex-start, wrap);
   }
   .label{
     color: $grey;

--- a/app/modules/entities/components/layouts/claim_layout.svelte
+++ b/app/modules/entities/components/layouts/claim_layout.svelte
@@ -1,7 +1,6 @@
 <script>
   import Spinner from '#general/components/spinner.svelte'
   import { getSubEntitiesSections } from '#entities/components/lib/entities'
-  import { byPublicationDate } from '#entities/lib/entities'
   import BaseLayout from './base_layout.svelte'
   import EntityImage from '../entity_image.svelte'
   import Summary from '#entities/components/layouts/summary.svelte'
@@ -39,7 +38,7 @@
 
   let sections, waitingForReverseEntities, flash
   function getSections () {
-    waitingForReverseEntities = getSubEntitiesSections({ entity, sortFn: byPublicationDate, property })
+    waitingForReverseEntities = getSubEntitiesSections({ entity, property })
       .then(res => sections = res)
       .catch(err => flash = err)
   }

--- a/app/modules/entities/components/layouts/collection.svelte
+++ b/app/modules/entities/components/layouts/collection.svelte
@@ -1,7 +1,6 @@
 <script>
   import Spinner from '#general/components/spinner.svelte'
   import { getSubEntitiesSections } from '#entities/components/lib/entities'
-  import { byPublicationDate } from '#entities/lib/entities'
   import BaseLayout from './base_layout.svelte'
   import Infobox from './infobox.svelte'
   import Summary from '#entities/components/layouts/summary.svelte'
@@ -25,7 +24,7 @@
 
   let sections, waitingForSubEntities, flash
   function getSections () {
-    waitingForSubEntities = getSubEntitiesSections({ entity, sortFn: byPublicationDate })
+    waitingForSubEntities = getSubEntitiesSections({ entity })
       .then(res => sections = res)
       .catch(err => flash = err)
   }

--- a/app/modules/entities/components/layouts/collection.svelte
+++ b/app/modules/entities/components/layouts/collection.svelte
@@ -13,7 +13,7 @@
   import { debounce } from 'underscore'
   import { onChange } from '#lib/svelte/svelte'
 
-  export let entity, standalone
+  export let entity
 
   const { uri } = entity
   runEntityNavigate(entity)
@@ -40,7 +40,7 @@
   <div class="entity-layout" slot="entity">
     <div class="top-section">
       <div class="work-section">
-        <EntityTitle {entity} {standalone} />
+        <EntityTitle {entity} />
         <Infobox
           claims={entity.claims}
           entityType={entity.type}

--- a/app/modules/entities/components/layouts/deduplicate_homonyms.svelte
+++ b/app/modules/entities/components/layouts/deduplicate_homonyms.svelte
@@ -128,7 +128,7 @@
               {/if}
               <EntityListRow
                 entity={homonym}
-                displayUri={true}
+                isUriToDisplay={true}
               />
             </div>
             {#if entity.type === 'human'}

--- a/app/modules/entities/components/layouts/edition.svelte
+++ b/app/modules/entities/components/layouts/edition.svelte
@@ -13,7 +13,7 @@
   import WorksOtherEditions from '#entities/components/layouts/works_other_editions.svelte'
   import { addWorksClaims } from '#entities/components/lib/entities'
 
-  export let entity, works, standalone
+  export let entity, works
 
   let showMap, itemsListsWrapperEl, mapWrapperEl
 
@@ -38,7 +38,7 @@
         </div>
       {/if}
       <div class="info-wrapper">
-        <EntityTitle {entity} {standalone} />
+        <EntityTitle {entity} />
         <div class="infobox-wrapper">
           <div class="author-and-info">
             <AuthorsInfo {claims} />

--- a/app/modules/entities/components/layouts/editions_list_actions.svelte
+++ b/app/modules/entities/components/layouts/editions_list_actions.svelte
@@ -168,7 +168,7 @@
 <div class="sort-selector-wrapper menu">
   <SortEntitiesBy
     sortingType="edition"
-    bind:entities={editions}
+    bind:entities={initialEditions}
     {waitingForItems}
   />
 </div>

--- a/app/modules/entities/components/layouts/entity_list_row.svelte
+++ b/app/modules/entities/components/layouts/entity_list_row.svelte
@@ -22,7 +22,7 @@
     relatedEntities,
     showInfobox = true,
     listDisplay = false,
-    displayUri
+    isUriToDisplay
 
   let { claims, label, image, images, pathname, serieOrdinal, subtitle, title, type, uri } = entity
 
@@ -69,7 +69,7 @@
         {#if subtitle}
           <span class="subtitle">{subtitle}</span>
         {/if}
-        {#if displayUri}
+        {#if isUriToDisplay}
           <a
             href={pathname}
             target="_blank"

--- a/app/modules/entities/components/layouts/publisher.svelte
+++ b/app/modules/entities/components/layouts/publisher.svelte
@@ -10,7 +10,7 @@
   import { setContext } from 'svelte'
   import { runEntityNavigate } from '#entities/lib/document_metadata'
 
-  export let entity, standalone
+  export let entity
   let flash
 
   const { uri } = entity
@@ -35,7 +35,7 @@
   <div class="entity-layout" slot="entity">
     <div class="top-section">
       <div class="work-section">
-        <EntityTitle {entity} {standalone} />
+        <EntityTitle {entity} />
         <Infobox
           claims={entity.claims}
           entityType={entity.type}

--- a/app/modules/entities/components/layouts/serie.svelte
+++ b/app/modules/entities/components/layouts/serie.svelte
@@ -15,7 +15,7 @@
   import { debounce } from 'underscore'
   import { onChange } from '#lib/svelte/svelte'
 
-  export let entity, standalone
+  export let entity
 
   const { uri } = entity
   runEntityNavigate(entity)
@@ -41,7 +41,7 @@
   <div class="entity-layout" slot="entity">
     <div class="top-section">
       <div class="work-section">
-        <EntityTitle {entity} {standalone} />
+        <EntityTitle {entity} />
         <AuthorsInfo claims={entity.claims} />
         <Infobox
           claims={omitNonInfoboxClaims(entity.claims)}

--- a/app/modules/entities/components/layouts/sort_entities_by.svelte
+++ b/app/modules/entities/components/layouts/sort_entities_by.svelte
@@ -11,9 +11,11 @@
   const optionsByName = getSortingOptionsByName(sortingType)
   const options = Object.values(optionsByName)
   let sortingName = Object.keys(optionsByName)?.[0]
+  let initialSorting = true
 
   $: option = optionsByName[sortingName]
   async function sortEntitiesBy () {
+    if (initialSorting) { return initialSorting = false }
     entities = await sortEntities({
       option,
       entities,

--- a/app/modules/entities/components/layouts/work.svelte
+++ b/app/modules/entities/components/layouts/work.svelte
@@ -24,7 +24,7 @@
   import { getRelativeEntitiesListLabel, getRelativeEntitiesProperties } from '#entities/components/lib/relative_entities_helpers.js'
   import Flash from '#lib/components/flash.svelte'
 
-  export let entity, standalone
+  export let entity
 
   let showMap, itemsListsWrapperEl, mapWrapperEl, flash
 
@@ -81,7 +81,7 @@
     <div class="top-section">
       <div class="work-section">
         <Flash state={flash} />
-        <EntityTitle {entity} {standalone} />
+        <EntityTitle {entity} />
         <AuthorsInfo {claims}
         />
         <Infobox

--- a/app/modules/entities/components/layouts/works_browser_section.svelte
+++ b/app/modules/entities/components/layouts/works_browser_section.svelte
@@ -18,8 +18,8 @@
 
   export let section, displayMode, facets, facetsSelectedValues, textFilterUris
 
-  const { entities: works, searchable = true, sortingType } = section
-  let { label, context } = section
+  const { searchable = true, sortingType } = section
+  let { entities: works, label, context } = section
 
   let filteredWorks = works
   let paginatedWorks = []
@@ -126,7 +126,7 @@
     {#if paginatedWorks.length > 1}
       <SortEntitiesBy
         {sortingType}
-        bind:entities={filteredWorks}
+        bind:entities={works}
       />
     {/if}
   </div>

--- a/app/modules/entities/components/lib/entities.js
+++ b/app/modules/entities/components/lib/entities.js
@@ -1,5 +1,5 @@
 import { i18n, I18n } from '#user/lib/i18n'
-import { getReverseClaims, getEntitiesByUris, serializeEntity, getEntitiesAttributesByUris } from '#entities/lib/entities'
+import { byNewestPublicationDate, getReverseClaims, getEntitiesByUris, serializeEntity, getEntitiesAttributesByUris } from '#entities/lib/entities'
 import { aggregateWorksClaims, inverseLabels } from '#entities/components/lib/claims_helpers'
 import { isNonEmptyArray } from '#lib/boolean_tests'
 import preq from '#lib/preq'
@@ -115,7 +115,7 @@ const urisGetterByType = {
   }
 }
 
-export const getSubEntitiesSections = async ({ entity, sortFn, property }) => {
+export const getSubEntitiesSections = async ({ entity, sortFn = byNewestPublicationDate, property }) => {
   const { type, refreshTimestamp } = entity
   const refresh = refreshTimestamp && !expired(refreshTimestamp, 1000)
   let sections

--- a/app/modules/entities/lib/get_entity_view_by_type.js
+++ b/app/modules/entities/lib/get_entity_view_by_type.js
@@ -1,12 +1,11 @@
 import error_ from '#lib/error'
 import { getEntitiesByUris } from '#entities/lib/entities'
-const standalone = true
 
 export default async function getEntityViewByType (model, refresh) {
   const entity = model.toJSON()
   const { type } = model
   const displayMergeSuggestions = app.user.hasDataadminAccess
-  let props = { entity, standalone }
+  let props = { entity }
 
   const getter = entityViewSpecialGetterByType[type]
   if (getter != null) return getter(entity, refresh)
@@ -38,7 +37,7 @@ export default async function getEntityViewByType (model, refresh) {
   }
 
   if (View != null) {
-    const view = new View({ model, refresh, standalone, displayMergeSuggestions })
+    const view = new View({ model, refresh, displayMergeSuggestions })
     return { view }
   }
 }
@@ -53,7 +52,6 @@ const getEditionComponent = async (entity, refresh) => {
     props: {
       entity,
       works,
-      standalone
     }
   }
 }


### PR DESCRIPTION
When more than 15 authors are displayed, it makes it more readable.

ie. article with 200+ authors, such as `/entity/wd:Q22305005`

solves #407

before:
![2024-02-09_18-39_1](https://github.com/inventaire/inventaire-client/assets/5363918/d4a33677-505d-4abb-9feb-cc196a9e9aec)

after
![2024-02-09_18-39](https://github.com/inventaire/inventaire-client/assets/5363918/cffe7970-b358-451b-b125-74d1c7081d31)
