### PR TITLE
remove nullifying entities after merge

### DIFF
--- a/app/modules/entities/components/entity_merge.svelte
+++ b/app/modules/entities/components/entity_merge.svelte
@@ -18,7 +18,6 @@
       merging = true
       await mergeEntities(from, to)
       from = null
-      to = null
       flash = {
         type: 'success',
         message: I18n('success')


### PR DESCRIPTION
remove nullifying toEntity after merge

to leave a link to merged entity
    
solves #478
