### PR TITLE
entity_layout_actions: add 'refresh external databases data' button on edition layouts

### DIFF
--- a/app/lib/boolean_tests.js
+++ b/app/lib/boolean_tests.js
@@ -42,6 +42,8 @@ export const isWikidataPropertyId = bindedTest('WikidataPropertyId')
 export const isWikidataItemUri = bindedTest('WikidataItemUri')
 export const isWikidataPropertyUri = bindedTest('WikidataPropertyUri')
 
+export const isIsbnEntityUri = uri => uri.split(':')[0] === 'isbn'
+
 export const isNonNull = obj => obj != null
 
 export const isNonEmptyArray = array => _.isArray(array) && (array.length > 0)

--- a/app/lib/boolean_tests.js
+++ b/app/lib/boolean_tests.js
@@ -42,8 +42,6 @@ export const isWikidataPropertyId = bindedTest('WikidataPropertyId')
 export const isWikidataItemUri = bindedTest('WikidataItemUri')
 export const isWikidataPropertyUri = bindedTest('WikidataPropertyUri')
 
-export const isIsbnEntityUri = uri => uri.split(':')[0] === 'isbn'
-
 export const isNonNull = obj => obj != null
 
 export const isNonEmptyArray = array => _.isArray(array) && (array.length > 0)

--- a/app/modules/entities/components/layouts/entity_layout_actions.svelte
+++ b/app/modules/entities/components/layouts/entity_layout_actions.svelte
@@ -7,13 +7,12 @@
   import Spinner from '#general/components/spinner.svelte'
   import app from '#app/app'
   import { tick } from 'svelte'
-  import { isIsbnEntityUri } from '#lib/boolean_tests'
 
   export let entity, showEntityEditButtons = true
 
   let waitForEntityRefresh
 
-  const { uri, type } = entity
+  const { uri, type, claims } = entity
 
   const refreshEntity = async () => {
     waitForEntityRefresh = preq.get(app.API.entities.getByUris(uri, true))
@@ -73,7 +72,7 @@
     />
   </li>
 {:else}
-  {#if isIsbnEntityUri(uri)}
+  {#if claims['wdt:P212']}
     <li>
       <button
         on:click={refreshEntity}

--- a/app/modules/entities/components/layouts/entity_layout_actions.svelte
+++ b/app/modules/entities/components/layouts/entity_layout_actions.svelte
@@ -7,6 +7,7 @@
   import Spinner from '#general/components/spinner.svelte'
   import app from '#app/app'
   import { tick } from 'svelte'
+  import { isIsbnEntityUri } from '#lib/boolean_tests'
 
   export let entity, showEntityEditButtons = true
 
@@ -72,6 +73,21 @@
     />
   </li>
 {:else}
+  {#if isIsbnEntityUri(uri)}
+    <li>
+      <button
+        on:click={refreshEntity}
+        title={I18n('refresh external databases data')}
+      >
+        {#await waitForEntityRefresh}
+          <Spinner />
+        {:then}
+          {@html iconFn('refresh')}
+        {/await}
+        <span class="button-text">{I18n('refresh external databases data')}</span>
+      </button>
+    </li>
+  {/if}
   <li>
     <Link
       url={`/entity/${uri}/history`}


### PR DESCRIPTION
to trigger the server behavior introduced by https://github.com/inventaire/inventaire/pull/734