### PR TITLE
entity_merge: add "view result" link below the flash message

### DIFF
--- a/app/modules/entities/components/entity_merge.svelte
+++ b/app/modules/entities/components/entity_merge.svelte
@@ -8,10 +8,11 @@
   import { isWikidataItemUri } from '#lib/boolean_tests'
   import { slide } from 'svelte/transition'
   import Spinner from '#components/spinner.svelte'
+  import Link from '#lib/components/link.svelte'
 
   export let from, to, type
 
-  let flash, typeName, merging
+  let flash, typeName, merging, lastMergeTargetUri
 
   async function merge () {
     try {
@@ -22,6 +23,7 @@
         type: 'success',
         message: I18n('success')
       }
+      lastMergeTargetUri = to
     } catch (err) {
       flash = err
     } finally {
@@ -71,6 +73,9 @@
   </section>
 
   <Flash bind:state={flash} />
+  {#if flash?.type === 'success' && lastMergeTargetUri}
+    <Link url={`/entity/${lastMergeTargetUri}`} text={i18n('View result')} classNames="classic-link" />
+  {/if}
 
   <button
     disabled={(!(from && to)) || merging}

--- a/app/modules/entities/components/entity_merge.svelte
+++ b/app/modules/entities/components/entity_merge.svelte
@@ -15,6 +15,7 @@
   let flash, typeName, merging, lastMergeTargetUri
 
   async function merge () {
+    flash = null
     try {
       merging = true
       await mergeEntities(from, to)


### PR DESCRIPTION
I just merged #481, but maybe I closed it to fast: I'm not fully certain it's enough to close #478, as clicking the autocomplete field with the preserved target entity would not get you to that page, but instead display the text input to change the entity value. So this PR proposes to display a more explicit link.