### PR TITLE
editor: add label removal possibilities

### DIFF
--- a/app/api/entities.ts
+++ b/app/api/entities.ts
@@ -75,6 +75,7 @@ export default {
 
   labels: {
     update: action('update-label'),
+    remove: action('remove-label'),
   },
 
   merge: action('merge'),

--- a/app/modules/entities/components/editor/edit_mode_buttons.svelte
+++ b/app/modules/entities/components/editor/edit_mode_buttons.svelte
@@ -7,6 +7,7 @@
   export let showSave = true
   export let showDelete = true
   export let saving = false
+  export let deleteButtonDisableMessage: string = null
 
   const dispatch = createEventDispatcher()
 </script>
@@ -37,8 +38,8 @@
   {#if showDelete !== false}
     <button
       class="tiny-button dangerous delete"
-      title={I18n('delete')}
-      disabled={saving}
+      title={deleteButtonDisableMessage != null ? deleteButtonDisableMessage : I18n('delete')}
+      disabled={saving || deleteButtonDisableMessage != null}
       on:click={() => dispatch('delete')}
     >
       {@html icon('trash')}

--- a/app/modules/entities/components/editor/labels_editor.svelte
+++ b/app/modules/entities/components/editor/labels_editor.svelte
@@ -9,7 +9,7 @@
   import { getActionKey } from '#app/lib/key_events'
   import preq from '#app/lib/preq'
   import { onChange } from '#app/lib/svelte/svelte'
-  import { alphabeticallySortedEntries, getNativeLangName } from '#entities/components/editor/lib/editors_helpers'
+  import { alphabeticallySortedEntries } from '#entities/components/editor/lib/editors_helpers'
   import { findMatchingSerieLabel, getWorkSeriesLabels } from '#entities/components/editor/lib/title_tip'
   import getLangsData from '#entities/lib/editor/get_langs_data'
   import getBestLangValue from '#entities/lib/get_best_lang_value'
@@ -18,6 +18,7 @@
   import { i18n, I18n } from '#user/lib/i18n'
   import DisplayModeButtons from './display_mode_buttons.svelte'
   import EditModeButtons from './edit_mode_buttons.svelte'
+  import OtherLanguage from './other_language.svelte'
   import type { WikimediaLanguageCode } from 'wikibase-sdk'
 
   export let entity
@@ -207,18 +208,12 @@
 
   <ul class="other-languages">
     {#each alphabeticallySortedEntries(labels) as [ lang, value ]}
-      {@const native = getNativeLangName(lang)}
-      {#if lang !== currentLang && isNonEmptyString(value)}
-        <li>
-          <button
-            class="edit-other-language"
-            on:click={() => editLanguageValue(lang)}
-          >
-            <span class="lang">{lang} {#if native}- {native}{/if}</span>
-            <span class="other-value">{value}</span>
-          </button>
-        </li>
-      {/if}
+      <OtherLanguage
+        {lang}
+        {value}
+        {currentLang}
+        on:editLanguageValue={e => editLanguageValue(e.detail)}
+      />
     {/each}
   </ul>
 
@@ -254,17 +249,6 @@
     max-block-size: 10em;
     overflow: auto;
     margin-block-start: 1em;
-    .edit-other-language{
-      inline-size: 100%;
-      margin: 0.5em 0;
-      padding: 0.5em 0;
-      @include display-flex(row, center, flex-start);
-      @include bg-hover(white, 5%);
-      text-align: start;
-    }
-  }
-  .other-value{
-    user-select: text;
   }
   .undo{
     flex: 1;
@@ -302,16 +286,9 @@
   }
   /* Large screens */
   @media screen and (min-width: $smaller-screen){
-    select, .other-languages .lang{
+    select{
       inline-size: 10em;
       block-size: 100%;
-    }
-    .lang{
-      padding: 0 1rem;
-      font-size: 0.9rem;
-    }
-    .other-value{
-      margin: 0 1.1em;
     }
     .language-values{
       @include display-flex(row, stretch, center);
@@ -321,7 +298,7 @@
       @include display-flex(row, stretch);
       .input-wrapper, .value-display{
         block-size: 100%;
-        margin: 0 0.5em;
+        margin: 0 1em;
       }
       .value-display{
         @include bg-hover(white, 5%);

--- a/app/modules/entities/components/editor/labels_editor.svelte
+++ b/app/modules/entities/components/editor/labels_editor.svelte
@@ -12,6 +12,7 @@
   import getLangsData from '#entities/lib/editor/get_langs_data'
   import getBestLangValue from '#entities/lib/get_best_lang_value'
   import { typeHasName } from '#entities/lib/types/entities_types'
+  import type { EntityUri, Label } from '#server/types/entity'
   import { i18n, I18n } from '#user/lib/i18n'
   import DisplayModeButtons from './display_mode_buttons.svelte'
   import EditModeButtons from './edit_mode_buttons.svelte'
@@ -73,7 +74,7 @@
     return updateOrRemoveLabel(uri, currentLang)
   }
 
-  function updateOrRemoveLabel (uri, lang, value) {
+  function updateOrRemoveLabel (uri: EntityUri, lang: WikimediaLanguageCode, value?: Label) {
     // Keep displaying a blank row when value is falsy, so that,
     // when removing label, user may still edit it after
     labels[lang] = value || ''

--- a/app/modules/entities/components/editor/labels_editor.svelte
+++ b/app/modules/entities/components/editor/labels_editor.svelte
@@ -207,7 +207,7 @@
   </div>
 
   <ul class="other-languages">
-    {#each alphabeticallySortedEntries(labels) as [ lang, value ]}
+    {#each alphabeticallySortedEntries(labels) as [ lang, value ] (lang)}
       <OtherLanguage
         {lang}
         {value}

--- a/app/modules/entities/components/editor/labels_editor.svelte
+++ b/app/modules/entities/components/editor/labels_editor.svelte
@@ -248,7 +248,6 @@
   .other-languages{
     max-block-size: 10em;
     overflow: auto;
-    margin-block-start: 1em;
   }
   .undo{
     flex: 1;

--- a/app/modules/entities/components/editor/other_language.svelte
+++ b/app/modules/entities/components/editor/other_language.svelte
@@ -35,14 +35,14 @@
     user-select: text;
   }
   /* Large screens */
-  @media screen and (min-width: $small-screen){
+  @media screen and (min-width: $smaller-screen){
     .other-value{
       margin: 0 1.1em;
     }
     .lang{
       inline-size: 10em;
       block-size: 100%;
-      padding: 0 1rem;
+      padding-inline-start: 0.7rem;
       font-size: 0.9rem;
     }
   }

--- a/app/modules/entities/components/editor/other_language.svelte
+++ b/app/modules/entities/components/editor/other_language.svelte
@@ -1,0 +1,49 @@
+<script>
+  import { createEventDispatcher } from 'svelte'
+  import { isNonEmptyString } from '#app/lib/boolean_tests'
+  import { getNativeLangName } from '#entities/components/editor/lib/editors_helpers'
+
+  const dispatch = createEventDispatcher()
+
+  export let lang, value, currentLang
+
+  $: native = getNativeLangName(lang)
+  $: isNotEmptyNorRemoved = isNonEmptyString(value) || value !== Symbol.for('removed')
+</script>
+{#if lang !== currentLang && isNotEmptyNorRemoved}
+  <li>
+    <button
+      class="edit-other-language"
+      on:click={() => dispatch('editLanguageValue', lang)}
+    >
+      <span class="lang">{lang} {#if native}- {native}{/if}</span>
+      <span class="other-value">{value}</span>
+    </button>
+  </li>
+{/if}
+<style lang="scss">
+  @import "#general/scss/utils";
+  .edit-other-language{
+    inline-size: 100%;
+    margin: 0.5em 0;
+    padding: 0.5em 0;
+    @include display-flex(row, center, flex-start);
+    @include bg-hover(white, 5%);
+    text-align: start;
+  }
+  .other-value{
+    user-select: text;
+  }
+  /* Large screens */
+  @media screen and (min-width: $small-screen){
+    .other-value{
+      margin: 0 1.1em;
+    }
+    .lang{
+      inline-size: 10em;
+      block-size: 100%;
+      padding: 0 1rem;
+      font-size: 0.9rem;
+    }
+  }
+</style>

--- a/app/modules/entities/lib/get_best_lang_value.ts
+++ b/app/modules/entities/lib/get_best_lang_value.ts
@@ -1,4 +1,5 @@
 import { uniq } from 'underscore'
+import { isNonEmptyString } from '#app/lib/boolean_tests'
 // data: labels or descriptions
 export default function (lang, originalLang, data) {
   if (!data) return {}
@@ -11,7 +12,7 @@ export default function (lang, originalLang, data) {
     if (value instanceof Array) {
       value = value[0]
     }
-    if (value != null) {
+    if (isNonEmptyString(value)) {
       return { value, lang: nextLang }
     }
   }


### PR DESCRIPTION
While this feature is implemented by doing some duck typing a bit (aka depending on whether `value` is defined as `updateOrRemoveLabel`, it will update or remove label accordingly), but the cases are a bit complex if you want to add the delete button (it would simplify a lot not to have it, but it does follow claim editor mechanism).