### PR TITLE
Entities delete requests

### DIFF
--- a/app/modules/entities/components/editor/entity_edit_menu.svelte
+++ b/app/modules/entities/components/editor/entity_edit_menu.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import { escapeExpression } from 'handlebars/runtime'
   import { API } from '#app/api/api'
   import app from '#app/app'
   import Flash from '#app/lib/components/flash.svelte'
   import Link from '#app/lib/components/link.svelte'
   import { icon } from '#app/lib/icons'
   import preq from '#app/lib/preq'
+  import { wait } from '#app/lib/promises'
   import { unprefixify } from '#app/lib/wikimedia/wikidata'
   import Dropdown from '#components/dropdown.svelte'
   import Modal from '#components/modal.svelte'
@@ -71,23 +73,26 @@
     app.execute('show:settings:display')
   }
 
+  let showDeletionConfirmationModal = false
   function deleteEntity () {
     flash = null
-    app.execute('ask:confirmation', {
-      confirmationText: I18n('delete_entity_confirmation', { label }),
-      action: _deleteEntity,
-    })
+    deletionConfirmationFlash = null
+    showDeletionConfirmationModal = true
   }
 
+  let deletionConfirmationFlash
+  let deleting = false
   async function _deleteEntity () {
     try {
+      deleting = true
       await preq.post(API.entities.delete, { uris: [ invUri ] })
-      // Let the time to the confirmation modal to display a success check
-      setTimeout(() => app.execute('show:home'), 500)
+      deleting = false
+      await wait(800)
+      app.execute('show:home')
     } catch (err) {
-      // TODO: recover displayDeteEntityErrorContext feature to show rich error message
-      flash = err
-      throw err
+      deletionConfirmationFlash = err
+    } finally {
+      deleting = false
     }
   }
 </script>
@@ -214,6 +219,31 @@
   </Modal>
 {/if}
 
+{#if showDeletionConfirmationModal}
+  <Modal on:closeModal={() => showDeletionConfirmationModal = false}>
+    <div class="delete-confirmation">
+      <p>{@html I18n('delete_entity_confirmation', { label: escapeExpression(label) })}</p>
+      <button
+        class="button grey radius bold"
+        on:click={() => showDeletionConfirmationModal = false}
+        disabled={deleting}
+      >
+        {@html icon('cross')}
+        {I18n('cancel')}
+      </button>
+      <button
+        class="button alert"
+        on:click={_deleteEntity}
+        disabled={deleting}
+      >
+        {@html icon('trash')}
+        {I18n('delete')}
+      </button>
+      <Flash state={deletionConfirmationFlash} />
+    </div>
+  </Modal>
+{/if}
+
 <style lang="scss">
   @import "#general/scss/utils";
   .menu-wrapper{
@@ -289,6 +319,12 @@
     }
     .identifier{
       @include identifier;
+    }
+  }
+  .delete-confirmation{
+    text-align: center;
+    p{
+      margin-block-end: 1rem;
     }
   }
 </style>

--- a/app/modules/entities/components/editor/entity_edit_menu.svelte
+++ b/app/modules/entities/components/editor/entity_edit_menu.svelte
@@ -19,7 +19,6 @@
   let flash
   const { uri, isWikidataEntity, label, historyPathname } = entity
   const { invUri, wdUri } = entity
-  const { hasDataadminAccess } = app.user
   let wikidataUrl, wikidataHistoryUrl
   if (wdUri) {
     wikidataUrl = getWikidataUrl(wdUri)
@@ -83,7 +82,8 @@
   async function _deleteEntity () {
     try {
       await preq.post(API.entities.delete, { uris: [ invUri ] })
-      app.execute('show:entity:edit', uri)
+      // Let the time to the confirmation modal to display a success check
+      setTimeout(() => app.execute('show:home'), 500)
     } catch (err) {
       // TODO: recover displayDeteEntityErrorContext feature to show rich error message
       flash = err
@@ -131,18 +131,16 @@
           icon="compress"
         />
       </li>
-      {#if hasDataadminAccess}
-        {#if canBeDeleted}
-          <li>
-            <button
-              title={I18n('delete entity')}
-              on:click={deleteEntity}
-            >
-              {@html icon('trash')}
-              {I18n('delete')}
-            </button>
-          </li>
-        {/if}
+      {#if canBeDeleted}
+        <li>
+          <button
+            title={I18n('delete entity')}
+            on:click={deleteEntity}
+          >
+            {@html icon('trash')}
+            {I18n('delete')}
+          </button>
+        </li>
       {/if}
       {#if !isWikidataEntity}
         <li>

--- a/app/modules/general/components/top_bar_buttons.svelte
+++ b/app/modules/general/components/top_bar_buttons.svelte
@@ -100,6 +100,14 @@
               stopClickPropagation={false}
             />
           </li>
+          {#if app.user.hasDataadminAccess}
+            <Link
+              icon="server"
+              url="/tasks"
+              text={I18n('resolve tasks')}
+              stopClickPropagation={false}
+            />
+          {/if}
           <li>
             <Link
               icon="info-circle"

--- a/app/modules/tasks/components/dashboard/tasks_dashboard.svelte
+++ b/app/modules/tasks/components/dashboard/tasks_dashboard.svelte
@@ -5,6 +5,7 @@
 
   const waitForTasksCounts = getTasksCounts()
 
+  const deleteEntitiesTypes = [ 'human', 'work', 'edition', 'serie', 'publisher', 'collection' ]
   const mergeEntitiesTypes = [ 'human', 'work', 'edition', 'serie', 'publisher', 'collection' ]
   const deduplicateEntitiesTypes = [ 'human', 'work' ]
   app.navigate('/tasks')
@@ -24,6 +25,20 @@
             {entitiesType}
             tasksCount={tasksCountByTypeAndEntitiesType.merge[entitiesType] || 0}
             type="merge"
+          />
+        {/each}
+      </div>
+    {/if}
+    {#if tasksCountByTypeAndEntitiesType.delete}
+      <h2>
+        {I18n('user delete request')}
+      </h2>
+      <div class="sections">
+        {#each deleteEntitiesTypes as entitiesType}
+          <DashboardSection
+            {entitiesType}
+            tasksCount={tasksCountByTypeAndEntitiesType.delete[entitiesType] || 0}
+            type="delete"
           />
         {/each}
       </div>

--- a/app/modules/tasks/components/dashboard/tasks_dashboard.svelte
+++ b/app/modules/tasks/components/dashboard/tasks_dashboard.svelte
@@ -1,13 +1,9 @@
 <script>
   import DashboardSection from '#tasks/components/dashboard/dashboard_section.svelte'
-  import { getTasksCounts } from '#tasks/components/lib/tasks_helpers'
+  import { getTasksCounts, entitiesTypesByTypes } from '#tasks/components/lib/tasks_helpers'
   import { I18n } from '#user/lib/i18n'
 
   const waitForTasksCounts = getTasksCounts()
-
-  const deleteEntitiesTypes = [ 'human', 'work', 'edition', 'serie', 'publisher', 'collection' ]
-  const mergeEntitiesTypes = [ 'human', 'work', 'edition', 'serie', 'publisher', 'collection' ]
-  const deduplicateEntitiesTypes = [ 'human', 'work' ]
   app.navigate('/tasks')
 </script>
 <div class="dashboard-wrapper">
@@ -20,7 +16,7 @@
         {I18n('user merge request')}
       </h2>
       <div class="sections">
-        {#each mergeEntitiesTypes as entitiesType}
+        {#each entitiesTypesByTypes.merge as entitiesType}
           <DashboardSection
             {entitiesType}
             tasksCount={tasksCountByTypeAndEntitiesType.merge[entitiesType] || 0}
@@ -34,7 +30,7 @@
         {I18n('user delete request')}
       </h2>
       <div class="sections">
-        {#each deleteEntitiesTypes as entitiesType}
+        {#each entitiesTypesByTypes.delete as entitiesType}
           <DashboardSection
             {entitiesType}
             tasksCount={tasksCountByTypeAndEntitiesType.delete[entitiesType] || 0}
@@ -48,7 +44,7 @@
         {I18n('deduplicate tasks')}
       </h2>
       <div class="sections">
-        {#each deduplicateEntitiesTypes as entitiesType}
+        {#each entitiesTypesByTypes.deduplicate as entitiesType}
           <DashboardSection
             {entitiesType}
             type="deduplicate"

--- a/app/modules/tasks/components/delete_layout.svelte
+++ b/app/modules/tasks/components/delete_layout.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte'
+  import { API } from '#app/api/api'
+  import preq, { treq } from '#app/lib/preq'
+  import { onChange, BubbleUpComponentEvent } from '#app/lib/svelte/svelte'
+  import { serializeEntity } from '#entities/lib/entities'
+  import Spinner from '#general/components/spinner.svelte'
+  import type { GetEntitiesByUrisResponse } from '#server/controllers/entities/by_uris_get'
+  import { areRedirects, updateTask } from '#tasks/components/lib/tasks_helpers.ts'
+  import TaskControls from './task_controls.svelte'
+  import TaskEntity from './task_entity.svelte'
+
+  export let task
+  export let entitiesType, type
+
+  const dispatch = createEventDispatcher()
+  const bubbleUpEvent = BubbleUpComponentEvent(dispatch)
+
+  let entity, flash, waitingForEntity, deleting
+  $: uri = task?.suspectUri
+
+  async function getAndAssignEntity () {
+    if (!task || task.state === 'merged') return
+    waitingForEntity = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris(uri))
+      .then(updateTaskAndAssignEntity)
+      .catch(err => {
+        flash = err
+      })
+  }
+
+  async function updateTaskAndAssignEntity (entitiesRes: GetEntitiesByUrisResponse) {
+    const { entities, redirects } = entitiesRes
+    if (areRedirects(entities, redirects)) {
+      await updateTask(task._id, 'state', 'merged')
+      return dispatch('next')
+    }
+    entity = serializeEntity(entities[uri])
+  }
+
+  async function deleteTaskEntity () {
+    deleting = true
+    // Optimistic UI: go to the next candidates without waiting for the merge confirmation
+    dispatch('next')
+    await preq.post(API.entities.delete, { uris: [ uri ] })
+      .catch(err => {
+        flash = err
+      })
+      .finally(() => deleting = false)
+  }
+
+  $: treatedTask = task && task.state && task.state !== undefined
+  $: onChange(uri, getAndAssignEntity)
+</script>
+{#await waitingForEntity}
+  <span class="loading"><Spinner /></span>
+{/await}
+{#if !treatedTask}
+  <div class="entity">
+    {#key entity}
+      <TaskEntity {entity} />
+    {/key}
+  </div>
+{:else}
+  <div class="error-wrapper">
+    <pre>{JSON.stringify(task, null, 2)}</pre>
+  </div>
+{/if}
+<TaskControls
+  {task}
+  {flash}
+  actionTitle={`Delete "${entity?.label}"\nShortkey: d`}
+  on:action={deleteTaskEntity}
+  on:next={bubbleUpEvent}
+  bind:doingAction={deleting}
+/>
+<style lang="scss">
+  @import "#general/scss/utils";
+  .entities-section{
+    @include display-flex(row, flex-start, flex-start);
+    background-color: #ddd;
+  }
+  .from-entity{
+    min-height: 100vh;
+    padding-inline-start: 1em;
+    flex: 1 0 0;
+  }
+  .to-entity{
+    min-height: 100vh;
+    background-color: $light-grey;
+    padding-inline-start: 1em;
+    flex: 1 0 0;
+  }
+  h2{
+    @include display-flex(row, null, center);
+    @include sans-serif;
+    font-size: 1.2rem;
+    margin: 0;
+    padding-block-start: 0.3em;
+  }
+  .error-wrapper{
+    background-color: $light-grey;
+    max-width: 40em;
+    margin: 1em auto;
+    padding: 1em;
+  }
+  .swap{
+    position: relative;
+    inset-inline-start: 1.3em;
+    inset-block-start: 30vh;
+    background-color: white;
+    padding: 0.5em;
+    border-radius: 50%;
+  }
+  .loading{
+    position: absolute;
+    margin: 0 auto;
+    padding-block-start: 0.5em;
+    width: 100%;
+  }
+</style>

--- a/app/modules/tasks/components/delete_layout.svelte
+++ b/app/modules/tasks/components/delete_layout.svelte
@@ -19,7 +19,7 @@
   $: uri = task?.suspectUri
 
   async function getAndAssignEntity () {
-    if (!task || task.state === 'treated') return
+    if (!task || task.state === 'processed') return
     waitingForEntity = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris(uri))
       .then(updateTaskAndAssignEntity)
       .catch(err => {
@@ -30,7 +30,7 @@
   async function updateTaskAndAssignEntity (entitiesRes: GetEntitiesByUrisResponse) {
     const { entities, redirects } = entitiesRes
     if (areRedirects(entities, redirects)) {
-      await updateTask(task._id, 'state', 'treated')
+      await updateTask(task._id, 'state', 'processed')
       return dispatch('next')
     }
     entity = serializeEntity(entities[uri])
@@ -47,13 +47,13 @@
       .finally(() => deleting = false)
   }
 
-  $: treatedTask = task && task.state && task.state !== undefined
+  $: processedTask = task && task.state && task.state !== undefined
   $: onChange(uri, getAndAssignEntity)
 </script>
 {#await waitingForEntity}
   <span class="loading"><Spinner /></span>
 {/await}
-{#if !treatedTask}
+{#if !processedTask}
   <div class="entity">
     {#key entity}
       <TaskEntity {entity} />
@@ -71,7 +71,7 @@
   on:action={deleteTaskEntity}
   on:next={bubbleUpEvent}
   bind:doingAction={deleting}
-  {treatedTask}
+  {processedTask}
 />
 <style lang="scss">
   @import "#general/scss/utils";

--- a/app/modules/tasks/components/delete_layout.svelte
+++ b/app/modules/tasks/components/delete_layout.svelte
@@ -20,7 +20,7 @@
   $: uri = task?.suspectUri
 
   async function getAndAssignEntity () {
-    if (!task || task.state === 'merged') return
+    if (!task || task.state === 'treated') return
     waitingForEntity = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris(uri))
       .then(updateTaskAndAssignEntity)
       .catch(err => {
@@ -31,7 +31,7 @@
   async function updateTaskAndAssignEntity (entitiesRes: GetEntitiesByUrisResponse) {
     const { entities, redirects } = entitiesRes
     if (areRedirects(entities, redirects)) {
-      await updateTask(task._id, 'state', 'merged')
+      await updateTask(task._id, 'state', 'treated')
       return dispatch('next')
     }
     entity = serializeEntity(entities[uri])
@@ -72,6 +72,7 @@
   on:action={deleteTaskEntity}
   on:next={bubbleUpEvent}
   bind:doingAction={deleting}
+  {treatedTask}
 />
 <style lang="scss">
   @import "#general/scss/utils";

--- a/app/modules/tasks/components/delete_layout.svelte
+++ b/app/modules/tasks/components/delete_layout.svelte
@@ -11,7 +11,6 @@
   import TaskEntity from './task_entity.svelte'
 
   export let task
-  export let entitiesType, type
 
   const dispatch = createEventDispatcher()
   const bubbleUpEvent = BubbleUpComponentEvent(dispatch)
@@ -76,41 +75,11 @@
 />
 <style lang="scss">
   @import "#general/scss/utils";
-  .entities-section{
-    @include display-flex(row, flex-start, flex-start);
-    background-color: #ddd;
-  }
-  .from-entity{
-    min-height: 100vh;
-    padding-inline-start: 1em;
-    flex: 1 0 0;
-  }
-  .to-entity{
-    min-height: 100vh;
-    background-color: $light-grey;
-    padding-inline-start: 1em;
-    flex: 1 0 0;
-  }
-  h2{
-    @include display-flex(row, null, center);
-    @include sans-serif;
-    font-size: 1.2rem;
-    margin: 0;
-    padding-block-start: 0.3em;
-  }
   .error-wrapper{
     background-color: $light-grey;
     max-width: 40em;
     margin: 1em auto;
     padding: 1em;
-  }
-  .swap{
-    position: relative;
-    inset-inline-start: 1.3em;
-    inset-block-start: 30vh;
-    background-color: white;
-    padding: 0.5em;
-    border-radius: 50%;
   }
   .loading{
     position: absolute;

--- a/app/modules/tasks/components/lib/tasks_helpers.ts
+++ b/app/modules/tasks/components/lib/tasks_helpers.ts
@@ -1,4 +1,4 @@
-import { intersection, pluck } from 'underscore'
+import { intersection, pluck, values } from 'underscore'
 import { API } from '#app/api/api'
 import preq from '#app/lib/preq'
 import { getSerieOrWorkExtendedAuthorsUris } from '#app/modules/entities/lib/types/serie_alt'
@@ -24,6 +24,18 @@ export function hasMatchedLabel (entity, matchedTitles) {
   const entityLabels = Object.values(entity.labels)
   const matchedLabels = intersection(matchedTitles, entityLabels)
   return matchedLabels.length > 0
+}
+
+export async function updateTask (id, attribute, value) {
+  const params = { id, attribute, value }
+  return preq.put(API.tasks.update, params)
+}
+
+export function areRedirects (entities, redirects) {
+  if (Object.keys(redirects).length === 0) return
+  for (const entityUri of values(redirects)) {
+    if (entities[entityUri]) return true
+  }
 }
 
 const urisGetterByType = {

--- a/app/modules/tasks/components/lib/tasks_helpers.ts
+++ b/app/modules/tasks/components/lib/tasks_helpers.ts
@@ -16,6 +16,12 @@ export const calculateGlobalScore = task => {
   return Math.trunc(score * 100) / 100
 }
 
+export const entitiesTypesByTypes = {
+  delete: [ 'human', 'work', 'edition', 'serie', 'publisher', 'collection' ],
+  merge: [ 'human', 'work', 'edition', 'serie', 'publisher', 'collection' ],
+  deduplicate: [ 'human', 'work' ],
+}
+
 export function sortMatchedLabelsEntities (entities, matchedTitles) {
   return entities.sort((a, b) => hasMatchedLabel(a, matchedTitles) < hasMatchedLabel(b, matchedTitles) ? 1 : -1)
 }

--- a/app/modules/tasks/components/merge_layout.svelte
+++ b/app/modules/tasks/components/merge_layout.svelte
@@ -78,42 +78,43 @@
       matchedTitles = pluck(task.externalSourcesOccurrences, 'matchedTitles').flat()
     }
   }
-  $: isMerged = task && task.state === 'merged'
+  $: treatedTask = task && task.state
   $: onChange(task, updateFromAndToEntities)
 </script>
 {#await waitingForEntities}
   <span class="loading"><Spinner /></span>
 {/await}
-<div class="entities-section">
-  <div class="from-entity">
-    <h2>From</h2>
-    {#key from}
-      <TaskEntity
-        entity={from}
-        {matchedTitles}
-      />
-    {/key}
+{#if !treatedTask}
+  <div class="entities-section">
+    <div class="from-entity">
+      <h2>From</h2>
+      {#key from}
+        <TaskEntity
+          entity={from}
+          {matchedTitles}
+        />
+      {/key}
+    </div>
+    {#if areBothInvEntities}
+      <button
+        class="swap"
+        on:click={exchangeFromTo}
+        title={I18n('swap from and to entities')}
+      >
+        {@html icon('exchange')}
+      </button>
+    {/if}
+    <div class="to-entity">
+      <h2>To</h2>
+      {#key to}
+        <TaskEntity
+          entity={to}
+          {matchedTitles}
+        />
+      {/key}
+    </div>
   </div>
-  {#if areBothInvEntities}
-    <button
-      class="swap"
-      on:click={exchangeFromTo}
-      title={I18n('swap from and to entities')}
-    >
-      {@html icon('exchange')}
-    </button>
-  {/if}
-  <div class="to-entity">
-    <h2>To</h2>
-    {#key to}
-      <TaskEntity
-        entity={to}
-        {matchedTitles}
-      />
-    {/key}
-  </div>
-</div>
-{#if isMerged}
+{:else}
   <div class="error-wrapper">
     <pre>{JSON.stringify(task, null, 2)}</pre>
   </div>

--- a/app/modules/tasks/components/merge_layout.svelte
+++ b/app/modules/tasks/components/merge_layout.svelte
@@ -25,7 +25,7 @@
   $: toUri = task?.suggestionUri
 
   async function updateFromAndToEntities () {
-    if (!task || task.state === 'treated') return
+    if (!task || task.state === 'processed') return
     waitingForEntities = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris([ fromUri, toUri ]))
       .then(updateTaskAndAssignFromToEntities(fromUri, toUri))
       .catch(err => {
@@ -36,7 +36,7 @@
   const updateTaskAndAssignFromToEntities = (fromUri, toUri) => async (entitiesRes: GetEntitiesByUrisResponse) => {
     const { entities, redirects } = entitiesRes
     if (areRedirects(entities, redirects)) {
-      await updateTask(task._id, 'state', 'treated')
+      await updateTask(task._id, 'state', 'processed')
       return dispatch('next')
     }
     areBothInvEntities = isInvEntityUri(fromUri) && isInvEntityUri(toUri)
@@ -77,13 +77,13 @@
       matchedTitles = pluck(task.externalSourcesOccurrences, 'matchedTitles').flat()
     }
   }
-  $: treatedTask = task && task.state && task.state !== undefined
+  $: processedTask = task && task.state && task.state !== undefined
   $: onChange(task, updateFromAndToEntities)
 </script>
 {#await waitingForEntities}
   <span class="loading"><Spinner /></span>
 {/await}
-{#if !treatedTask}
+{#if !processedTask}
   <div class="entities-section">
     <div class="from-entity">
       <h2>From</h2>
@@ -125,7 +125,7 @@
   on:action={mergeTaskEntities}
   on:next={bubbleUpEvent}
   bind:doingAction={merging}
-  {treatedTask}
+  {processedTask}
 />
 <style lang="scss">
   @import "#general/scss/utils";

--- a/app/modules/tasks/components/merge_layout.svelte
+++ b/app/modules/tasks/components/merge_layout.svelte
@@ -26,7 +26,7 @@
   $: toUri = task?.suggestionUri
 
   async function updateFromAndToEntities () {
-    if (!task || task.state === 'merged') return
+    if (!task || task.state === 'treated') return
     waitingForEntities = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris([ fromUri, toUri ]))
       .then(updateTaskAndAssignFromToEntities(fromUri, toUri))
       .catch(err => {
@@ -37,7 +37,7 @@
   const updateTaskAndAssignFromToEntities = (fromUri, toUri) => async (entitiesRes: GetEntitiesByUrisResponse) => {
     const { entities, redirects } = entitiesRes
     if (areRedirects(entities, redirects)) {
-      await updateTask(task._id, 'state', 'merged')
+      await updateTask(task._id, 'state', 'treated')
       return dispatch('next')
     }
     areBothInvEntities = isInvEntityUri(fromUri) && isInvEntityUri(toUri)
@@ -78,7 +78,7 @@
       matchedTitles = pluck(task.externalSourcesOccurrences, 'matchedTitles').flat()
     }
   }
-  $: treatedTask = task && task.state
+  $: treatedTask = task && task.state && task.state !== undefined
   $: onChange(task, updateFromAndToEntities)
 </script>
 {#await waitingForEntities}
@@ -126,6 +126,7 @@
   on:action={mergeTaskEntities}
   on:next={bubbleUpEvent}
   bind:doingAction={merging}
+  {treatedTask}
 />
 <style lang="scss">
   @import "#general/scss/utils";

--- a/app/modules/tasks/components/merge_layout.svelte
+++ b/app/modules/tasks/components/merge_layout.svelte
@@ -16,7 +16,6 @@
   import TaskEntity from './task_entity.svelte'
 
   export let task
-  export let entitiesType, type
 
   const dispatch = createEventDispatcher()
   const bubbleUpEvent = BubbleUpComponentEvent(dispatch)

--- a/app/modules/tasks/components/merge_layout.svelte
+++ b/app/modules/tasks/components/merge_layout.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte'
+  import { clone, pluck, values } from 'underscore'
+  import { API } from '#app/api/api'
+  import { icon } from '#app/lib/icons'
+  import preq, { treq } from '#app/lib/preq'
+  import { BubbleUpComponentEvent, onChange } from '#app/lib/svelte/svelte'
+  import { serializeEntity } from '#entities/lib/entities'
+  import Spinner from '#general/components/spinner.svelte'
+  import type { GetEntitiesByUrisResponse } from '#server/controllers/entities/by_uris_get'
+  import { I18n } from '#user/lib/i18n'
+  import TaskControls from './task_controls.svelte'
+  import TaskEntity from './task_entity.svelte'
+
+  export let task
+  export let entitiesType, type
+
+  const dispatch = createEventDispatcher()
+  const bubbleUpEvent = BubbleUpComponentEvent(dispatch)
+
+  let from, to, flash, matchedTitles, areBothInvEntities, waitingForEntities
+  $: fromUri = task?.suspectUri
+  $: toUri = task?.suggestionUri
+
+  async function updateFromAndToEntities () {
+    if (!task || task.state === 'merged') return
+    waitingForEntities = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris([ fromUri, toUri ]))
+      .then(updateTaskAndAssignFromToEntities(fromUri, toUri))
+      .catch(err => {
+        flash = err
+      })
+  }
+
+  const updateTaskAndAssignFromToEntities = (fromUri, toUri) => async (entitiesRes: GetEntitiesByUrisResponse) => {
+    const { entities, redirects } = entitiesRes
+    if (areRedirects(entities, redirects)) {
+      await updateTask(task._id, 'state', 'merged')
+      return dispatch('next')
+    }
+    areBothInvEntities = isInvEntityUri(fromUri) && isInvEntityUri(toUri)
+
+    assignFromToEntities(fromUri, toUri, entities)
+  }
+
+  function isInvEntityUri (uri) {
+    return uri.split(':')[0] === 'inv'
+  }
+
+  const assignFromToEntities = (fromUri, toUri, entities) => {
+    from = serializeEntity(entities[fromUri])
+    to = serializeEntity(entities[toUri])
+  }
+
+  function exchangeFromTo () {
+    const tmpFrom = clone(from)
+    from = to
+    to = tmpFrom
+  }
+
+  async function updateTask (id, attribute, value) {
+    const params = { id, attribute, value }
+    return preq.put(API.tasks.update, params)
+  }
+
+  function areRedirects (entities, redirects) {
+    if (Object.keys(redirects).length === 0) return
+    for (const entityUri of values(redirects)) {
+      if (entities[entityUri]) return true
+    }
+  }
+
+  $: {
+    if (task) {
+      matchedTitles = pluck(task.externalSourcesOccurrences, 'matchedTitles').flat()
+    }
+  }
+  $: isMerged = task && task.state === 'merged'
+  $: onChange(task, updateFromAndToEntities)
+</script>
+{#await waitingForEntities}
+  <span class="loading"><Spinner /></span>
+{/await}
+<div class="entities-section">
+  <div class="from-entity">
+    <h2>From</h2>
+    {#key from}
+      <TaskEntity
+        entity={from}
+        {matchedTitles}
+      />
+    {/key}
+  </div>
+  {#if areBothInvEntities}
+    <button
+      class="swap"
+      on:click={exchangeFromTo}
+      title={I18n('swap from and to entities')}
+    >
+      {@html icon('exchange')}
+    </button>
+  {/if}
+  <div class="to-entity">
+    <h2>To</h2>
+    {#key to}
+      <TaskEntity
+        entity={to}
+        {matchedTitles}
+      />
+    {/key}
+  </div>
+</div>
+{#if isMerged}
+  <div class="error-wrapper">
+    <pre>{JSON.stringify(task, null, 2)}</pre>
+  </div>
+{/if}
+<TaskControls
+  {task}
+  {from}
+  {to}
+  {flash}
+  on:next={bubbleUpEvent}
+/>
+<style lang="scss">
+  @import "#general/scss/utils";
+  .entities-section{
+    @include display-flex(row, flex-start, flex-start);
+    background-color: #ddd;
+  }
+  .from-entity{
+    min-height: 100vh;
+    padding-inline-start: 1em;
+    flex: 1 0 0;
+  }
+  .to-entity{
+    min-height: 100vh;
+    background-color: $light-grey;
+    padding-inline-start: 1em;
+    flex: 1 0 0;
+  }
+  h2{
+    @include display-flex(row, null, center);
+    @include sans-serif;
+    font-size: 1.2rem;
+    margin: 0;
+    padding-block-start: 0.3em;
+  }
+  .error-wrapper{
+    background-color: $light-grey;
+    max-width: 40em;
+    margin: 1em auto;
+    padding: 1em;
+  }
+  .swap{
+    position: relative;
+    inset-inline-start: 1.3em;
+    inset-block-start: 30vh;
+    background-color: white;
+    padding: 0.5em;
+    border-radius: 50%;
+  }
+  .loading{
+    position: absolute;
+    margin: 0 auto;
+    padding-block-start: 0.5em;
+    width: 100%;
+  }
+</style>

--- a/app/modules/tasks/components/merge_layout.svelte
+++ b/app/modules/tasks/components/merge_layout.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
-  import { clone, pluck, values } from 'underscore'
+  import { clone, pluck } from 'underscore'
   import { API } from '#app/api/api'
   import { icon } from '#app/lib/icons'
-  import preq, { treq } from '#app/lib/preq'
+  import { treq } from '#app/lib/preq'
   import { BubbleUpComponentEvent, onChange } from '#app/lib/svelte/svelte'
   import { serializeEntity } from '#entities/lib/entities'
   import mergeEntities from '#entities/views/editor/lib/merge_entities'
   import Spinner from '#general/components/spinner.svelte'
   import type { GetEntitiesByUrisResponse } from '#server/controllers/entities/by_uris_get'
   import type { EntityUri } from '#server/types/entity'
+  import { areRedirects, updateTask } from '#tasks/components/lib/tasks_helpers.ts'
   import { I18n } from '#user/lib/i18n'
   import TaskControls from './task_controls.svelte'
   import TaskEntity from './task_entity.svelte'
@@ -70,18 +71,6 @@
         flash = err
       })
       .finally(() => merging = false)
-  }
-
-  async function updateTask (id, attribute, value) {
-    const params = { id, attribute, value }
-    return preq.put(API.tasks.update, params)
-  }
-
-  function areRedirects (entities, redirects) {
-    if (Object.keys(redirects).length === 0) return
-    for (const entityUri of values(redirects)) {
-      if (entities[entityUri]) return true
-    }
   }
 
   $: {

--- a/app/modules/tasks/components/task_breadcrumb.svelte
+++ b/app/modules/tasks/components/task_breadcrumb.svelte
@@ -5,7 +5,7 @@
   import Dropdown from '#components/dropdown.svelte'
   import { getPluralType } from '#entities/lib/entities'
   import { entitiesTypesByTypes } from '#tasks/components/lib/tasks_helpers'
-  import { i18n } from '#user/lib/i18n'
+  import { I18n, i18n } from '#user/lib/i18n'
 
   export let entitiesType, type, taskId
   $: menuEntitiesTypes = without(entitiesTypesByTypes[type], entitiesType)
@@ -14,13 +14,13 @@
 <div class="breadcrumb">
   <Link
     url="/tasks"
-    text={i18n('dashboard')}
+    text={i18n('Tasks')}
     classNames="link"
   />
   <span class="separator">/</span>
   <Dropdown dropdownWidthBaseInEm={10}>
     <div slot="button-inner">
-      {i18n(type)}
+      {I18n(type)}
       {@html icon('chevron-down')}
     </div>
     <ul slot="dropdown-content">
@@ -28,7 +28,7 @@
         <li>
           <Link
             url="/tasks/{menuType}/humans/"
-            text={i18n(menuType)}
+            text={I18n(menuType)}
           />
         </li>
       {/each}
@@ -37,7 +37,7 @@
   <span class="separator">/</span>
   <Dropdown dropdownWidthBaseInEm={10}>
     <div slot="button-inner">
-      {i18n(entitiesType)}
+      {I18n(entitiesType)}
       {@html icon('chevron-down')}
     </div>
     <ul slot="dropdown-content">
@@ -45,7 +45,7 @@
         <li>
           <Link
             url="/tasks/{type}/{getPluralType(menuEntitiesType)}/"
-            text={i18n(menuEntitiesType)}
+            text={I18n(menuEntitiesType)}
           />
         </li>
       {/each}
@@ -65,7 +65,6 @@
     padding-block-end: 0.5em;
     background-color: #f3f3f3;
     color: $grey;
-    font-size: 0.9em;
     :global(.link){
       color: $grey;
     }
@@ -77,7 +76,6 @@
     [slot="button-inner"]{
       @include display-flex(row, center);
       color: $grey;
-      font-size: 0.9em;
       :global(.fa){
         margin-inline-start: 0.5em;
         font-size: 0.4em;
@@ -90,6 +88,9 @@
   li{
     @include bg-hover-svelte(#f3f3f3);
     @include shy-border;
-    padding: 0.5em;
+    :global(a){
+      display: block;
+      padding: 0.5em;
+    }
   }
 </style>

--- a/app/modules/tasks/components/task_breadcrumb.svelte
+++ b/app/modules/tasks/components/task_breadcrumb.svelte
@@ -1,0 +1,95 @@
+<script>
+  import { without } from 'underscore'
+  import Link from '#app/lib/components/link.svelte'
+  import { icon } from '#app/lib/icons'
+  import Dropdown from '#components/dropdown.svelte'
+  import { getPluralType } from '#entities/lib/entities'
+  import { entitiesTypesByTypes } from '#tasks/components/lib/tasks_helpers'
+  import { i18n } from '#user/lib/i18n'
+
+  export let entitiesType, type, taskId
+  $: menuEntitiesTypes = without(entitiesTypesByTypes[type], entitiesType)
+  $: menuTypes = without([ 'merge', 'delete', 'deduplicate' ], type)
+</script>
+<div class="breadcrumb">
+  <Link
+    url="/tasks"
+    text={i18n('dashboard')}
+    classNames="link"
+  />
+  <span class="separator">/</span>
+  <Dropdown dropdownWidthBaseInEm={10}>
+    <div slot="button-inner">
+      {i18n(type)}
+      {@html icon('chevron-down')}
+    </div>
+    <ul slot="dropdown-content">
+      {#each menuTypes as menuType}
+        <li>
+          <Link
+            url="/tasks/{menuType}/humans/"
+            text={i18n(menuType)}
+          />
+        </li>
+      {/each}
+    </ul>
+  </Dropdown>
+  <span class="separator">/</span>
+  <Dropdown dropdownWidthBaseInEm={10}>
+    <div slot="button-inner">
+      {i18n(entitiesType)}
+      {@html icon('chevron-down')}
+    </div>
+    <ul slot="dropdown-content">
+      {#each menuEntitiesTypes as menuEntitiesType}
+        <li>
+          <Link
+            url="/tasks/{type}/{getPluralType(menuEntitiesType)}/"
+            text={i18n(menuEntitiesType)}
+          />
+        </li>
+      {/each}
+    </ul>
+  </Dropdown>
+  {#if taskId}
+    <span class="separator">/</span>
+    {taskId}
+  {/if}
+</div>
+<style lang="scss">
+  @import "#general/scss/utils";
+  .breadcrumb{
+    @include display-flex(row, center);
+    padding-inline-start: 0.5em;
+    padding-block-start: 0.5em;
+    padding-block-end: 0.5em;
+    background-color: #f3f3f3;
+    color: $grey;
+    font-size: 0.9em;
+    :global(.link){
+      color: $grey;
+    }
+    :global(.dropdown-content){
+      background-color: white;
+      padding-block-end: 0;
+      @include radius;
+    }
+    [slot="button-inner"]{
+      @include display-flex(row, center);
+      color: $grey;
+      font-size: 0.9em;
+      :global(.fa){
+        margin-inline-start: 0.5em;
+        font-size: 0.4em;
+      }
+    }
+  }
+  .separator{
+    padding: 0 0.7em;
+  }
+  li{
+    @include bg-hover-svelte(#f3f3f3);
+    @include shy-border;
+    padding: 0.5em;
+  }
+</style>

--- a/app/modules/tasks/components/task_controls.svelte
+++ b/app/modules/tasks/components/task_controls.svelte
@@ -7,37 +7,20 @@
   import { icon } from '#app/lib/icons'
   import preq from '#app/lib/preq'
   import { onChange } from '#app/lib/svelte/svelte'
-  import mergeEntities from '#entities/views/editor/lib/merge_entities'
   import Spinner from '#general/components/spinner.svelte'
-  import type { EntityUri } from '#server/types/entity'
   import { I18n } from '#user/lib/i18n'
   import TaskInfo from './task_info.svelte'
   import TaskScores from './task_scores.svelte'
 
   const dispatch = createEventDispatcher()
 
-  export let task, from, to, flash
-
-  let merging
+  export let task, flash, doingAction, actionTitle
 
   function handleKeydown (event) {
     if (event.altKey || event.ctrlKey || event.shiftKey || event.metaKey) return
-    if (event.key === 'm') mergeTaskEntities()
+    if (event.key === 'm') dispatch('action')
     if (event.key === 'd') dismiss()
     else if (event.key === 'n') dispatch('next')
-  }
-
-  function mergeTaskEntities () {
-    if (!(from && to)) return
-    merging = true
-    // Optimistic UI: go to the next candidates without waiting for the merge confirmation
-    dispatch('next')
-    const params: [ EntityUri, EntityUri ] = [ from.uri, to.uri ]
-    mergeEntities(...params)
-      .catch(err => {
-        flash = err
-      })
-      .finally(() => merging = false)
   }
 
   function dismiss () {
@@ -73,12 +56,11 @@
       {/if}
     </div>
     <div class="actions">
-      {#if merging}<Spinner light={true} />{/if}
+      {#if doingAction}<Spinner light={true} />{/if}
       <button
         class="merge dangerous-button"
-        disabled={!(from && to)}
-        title={from?.uri && to?.uri ? `merge ${from?.uri} into ${to?.uri}\nShortkey: m` : 'Shortkey: m'}
-        on:click={() => mergeTaskEntities()}
+        title={actionTitle}
+        on:click={() => dispatch('action')}
       >
         {@html icon('compress')}{I18n('merge')}
       </button>

--- a/app/modules/tasks/components/task_controls.svelte
+++ b/app/modules/tasks/components/task_controls.svelte
@@ -14,7 +14,7 @@
 
   const dispatch = createEventDispatcher()
 
-  export let task, flash, doingAction, actionTitle, treatedTask
+  export let task, flash, doingAction, actionTitle, processedTask
 
   function handleKeydown (event) {
     if (event.altKey || event.ctrlKey || event.shiftKey || event.metaKey) return
@@ -38,10 +38,10 @@
 
   $: onChange(task, () => { flash = null })
   $: {
-    if (treatedTask) {
+    if (processedTask) {
       flash = {
         type: 'error',
-        message: I18n('this task has already been treated'),
+        message: I18n('this task has already been processed'),
       }
     }
   }
@@ -51,7 +51,7 @@
 <div class="controls" tabindex="-1" use:autofocus>
   <div class="buttons-wrapper">
     <div class="task-info-section">
-      {#if !treatedTask}
+      {#if !processedTask}
         {#if isNonEmptyArray(task.reporters)}
           <ul class="task-info">
             <TaskInfo {task} />
@@ -69,7 +69,7 @@
       <button
         class="merge dangerous-button"
         title={actionTitle}
-        disabled={treatedTask}
+        disabled={processedTask}
         on:click={() => dispatch('action')}
       >
         {#if task.type === 'delete'}
@@ -81,7 +81,7 @@
       <button
         class="dismiss grey-button"
         title={I18n('Archive this task. Shortkey: a')}
-        disabled={treatedTask}
+        disabled={processedTask}
         on:click={dismiss}
       >
         {@html icon('close')}{I18n('dismiss')}

--- a/app/modules/tasks/components/task_controls.svelte
+++ b/app/modules/tasks/components/task_controls.svelte
@@ -18,8 +18,12 @@
 
   function handleKeydown (event) {
     if (event.altKey || event.ctrlKey || event.shiftKey || event.metaKey) return
-    if (event.key === 'm') dispatch('action')
-    if (event.key === 'd') dismiss()
+    if (task.type === 'delete') {
+      if (event.key === 'd') dispatch('action')
+    } else {
+      if (event.key === 'm') dispatch('action')
+    }
+    if (event.key === 'a') dismiss()
     else if (event.key === 'n') dispatch('next')
   }
 
@@ -62,11 +66,15 @@
         title={actionTitle}
         on:click={() => dispatch('action')}
       >
-        {@html icon('compress')}{I18n('merge')}
+        {#if task.type === 'delete'}
+          {@html icon('trash')}{I18n('delete')}
+        {:else}
+          {@html icon('compress')}{I18n('merge')}
+        {/if}
       </button>
       <button
         class="dismiss grey-button"
-        title="Archive this task. Shortkey: d"
+        title={I18n('Archive this task. Shortkey: a')}
         on:click={dismiss}
       >
         {@html icon('close')}{I18n('dismiss')}

--- a/app/modules/tasks/components/task_controls.svelte
+++ b/app/modules/tasks/components/task_controls.svelte
@@ -14,7 +14,7 @@
 
   const dispatch = createEventDispatcher()
 
-  export let task, flash, doingAction, actionTitle
+  export let task, flash, doingAction, actionTitle, treatedTask
 
   function handleKeydown (event) {
     if (event.altKey || event.ctrlKey || event.shiftKey || event.metaKey) return
@@ -36,7 +36,6 @@
       .then(() => dispatch('next'))
   }
 
-  $: treatedTask = task && task.state
   $: onChange(task, () => { flash = null })
   $: {
     if (treatedTask) {

--- a/app/modules/tasks/components/task_controls.svelte
+++ b/app/modules/tasks/components/task_controls.svelte
@@ -36,27 +36,33 @@
       .then(() => dispatch('next'))
   }
 
+  $: treatedTask = task && task.state
+  $: onChange(task, () => { flash = null })
   $: {
-    if (task && task.state === 'merged') {
-      flash = new Error(I18n('this task has already been treated'))
+    if (treatedTask) {
+      flash = {
+        type: 'error',
+        message: I18n('this task has already been treated'),
+      }
     }
   }
-  $: onChange(task, () => { flash = null })
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
 <div class="controls" tabindex="-1" use:autofocus>
   <div class="buttons-wrapper">
     <div class="task-info-section">
-      {#if isNonEmptyArray(task.reporters)}
-        <ul class="task-info">
-          <TaskInfo {task} />
-        </ul>
-      {/if}
-      {#if task.externalSourcesOccurrences}
-        <ul class="task-info">
-          <TaskScores {task} />
-        </ul>
+      {#if !treatedTask}
+        {#if isNonEmptyArray(task.reporters)}
+          <ul class="task-info">
+            <TaskInfo {task} />
+          </ul>
+        {/if}
+        {#if task.externalSourcesOccurrences}
+          <ul class="task-info">
+            <TaskScores {task} />
+          </ul>
+        {/if}
       {/if}
     </div>
     <div class="actions">
@@ -64,6 +70,7 @@
       <button
         class="merge dangerous-button"
         title={actionTitle}
+        disabled={treatedTask}
         on:click={() => dispatch('action')}
       >
         {#if task.type === 'delete'}
@@ -75,6 +82,7 @@
       <button
         class="dismiss grey-button"
         title={I18n('Archive this task. Shortkey: a')}
+        disabled={treatedTask}
         on:click={dismiss}
       >
         {@html icon('close')}{I18n('dismiss')}
@@ -89,7 +97,7 @@
     </div>
   </div>
   {#if flash}
-    <div class="alerts">
+    <div class="flash">
       <Flash bind:state={flash} />
     </div>
   {/if}
@@ -124,7 +132,7 @@
     @include display-flex(row, center, space-between);
   }
 
-  .buttons-wrapper, .alerts, .actions{
+  .buttons-wrapper, .flash, .actions{
     @include display-flex(row, center, space-between);
   }
 
@@ -134,13 +142,8 @@
     font-family: $sans-serif;
   }
 
-  .alerts{
-    align-self: stretch;
-    min-width: 50%;
-    max-width: 30em;
+  .flash{
     margin: 0 auto;
-    background-color: $soft-red;
-    margin-block-start: 0.3em;
   }
 
   /* Smaller screens */

--- a/app/modules/tasks/components/task_info.svelte
+++ b/app/modules/tasks/components/task_info.svelte
@@ -8,17 +8,13 @@
 
   export let task
 
-  const { reporters: reportersIds, clue, entitiesType } = task
+  const { reporters: reportersIds, clue } = task
 
   let reporters
   const waitingForUsers = getUsersByIds(reportersIds)
     .then(res => reporters = Object.values(res))
 </script>
 
-<p>
-  <strong>{i18n('entities type')}: </strong>
-  {i18n(entitiesType)}
-</p>
 {#await waitingForUsers}
   <Spinner center={true} />
 {:then}

--- a/app/modules/tasks/components/task_layout.svelte
+++ b/app/modules/tasks/components/task_layout.svelte
@@ -62,15 +62,11 @@
     {#if type === 'delete'}
       <DeleteLayout
         {task}
-        {entitiesType}
-        {type}
         on:next={showNextTask}
       />
     {:else}
       <MergeLayout
         {task}
-        {entitiesType}
-        {type}
         on:next={showNextTask}
       />
     {/if}

--- a/app/modules/tasks/components/task_layout.svelte
+++ b/app/modules/tasks/components/task_layout.svelte
@@ -1,33 +1,23 @@
 <script lang="ts">
-  import { clone, pluck, values } from 'underscore'
   import { API } from '#app/api/api'
   import app from '#app/app'
   import Flash from '#app/lib/components/flash.svelte'
-  import { icon } from '#app/lib/icons'
-  import preq, { treq } from '#app/lib/preq'
-  import { onChange } from '#app/lib/svelte/svelte'
-  import { serializeEntity } from '#entities/lib/entities'
-  import Spinner from '#general/components/spinner.svelte'
-  import type { GetEntitiesByUrisResponse } from '#server/controllers/entities/by_uris_get'
+  import preq from '#app/lib/preq'
   import type { TaskId } from '#server/types/task'
   import { getNextTask } from '#tasks/lib/get_next_task.ts'
-  import { I18n } from '#user/lib/i18n'
+  import MergeLayout from './merge_layout.svelte'
   import NoTask from './no_task.svelte'
-  import TaskControls from './task_controls.svelte'
-  import TaskEntity from './task_entity.svelte'
 
   export let taskId: TaskId
   export let entitiesType, type
 
-  let task, from, to, flash, matchedTitles, areBothInvEntities, waitingForEntities
-  $: fromUri = task?.suspectUri
-  $: toUri = task?.suggestionUri
+  let task, flash
 
-  let nextTaskOffset
+  let nextTaskOffset = 0
   const waitForTask = getTask()
 
   async function getTask () {
-    const promise = taskId ? taskById() : nextTask()
+    const promise = taskId ? taskById() : showNextTask()
     return promise
       .catch(err => {
         flash = err
@@ -36,10 +26,11 @@
 
   async function taskById () {
     const { tasks } = await preq.get(API.tasks.byIds(taskId))
-    task = tasks[0]
+    task = tasks[0];
+    ({ type, entitiesType } = task)
   }
 
-  async function nextTask () {
+  async function showNextTask () {
     if (!entitiesType) ({ entitiesType } = task)
     if (!task) (nextTaskOffset = 0)
     const newTask = await getNextTask({ type, entitiesType, offset: nextTaskOffset })
@@ -56,158 +47,18 @@
     app.navigate('/tasks/none')
     nextTaskOffset = 0
     task = null
-    from = null
-    to = null
   }
-
-  async function updateFromAndToEntities () {
-    if (!task || task.state === 'merged') return
-    waitingForEntities = treq.get<GetEntitiesByUrisResponse>(API.entities.getByUris([ fromUri, toUri ]))
-      .then(updateTaskAndAssignFromToEntities(fromUri, toUri))
-      .catch(err => {
-        flash = err
-      })
-  }
-
-  const updateTaskAndAssignFromToEntities = (fromUri, toUri) => async (entitiesRes: GetEntitiesByUrisResponse) => {
-    const { entities, redirects } = entitiesRes
-    if (areRedirects(entities, redirects)) {
-      await updateTask(task._id, 'state', 'merged')
-      return nextTask()
-    }
-    areBothInvEntities = isInvEntityUri(fromUri) && isInvEntityUri(toUri)
-
-    assignFromToEntities(fromUri, toUri, entities)
-  }
-
-  function isInvEntityUri (uri) {
-    return uri.split(':')[0] === 'inv'
-  }
-
-  const assignFromToEntities = (fromUri, toUri, entities) => {
-    from = serializeEntity(entities[fromUri])
-    to = serializeEntity(entities[toUri])
-  }
-
-  function exchangeFromTo () {
-    const tmpFrom = clone(from)
-    from = to
-    to = tmpFrom
-  }
-
-  async function updateTask (id, attribute, value) {
-    const params = { id, attribute, value }
-    return preq.put(API.tasks.update, params)
-  }
-
-  function areRedirects (entities, redirects) {
-    if (Object.keys(redirects).length === 0) return
-    for (const entityUri of values(redirects)) {
-      if (entities[entityUri]) return true
-    }
-  }
-
-  $: {
-    if (task) {
-      matchedTitles = pluck(task.externalSourcesOccurrences, 'matchedTitles').flat()
-    }
-  }
-  $: isMerged = task && task.state === 'merged'
-  $: onChange(task, updateFromAndToEntities)
 </script>
 {#await waitForTask then}
   {#if task}
-    {#await waitingForEntities}
-      <span class="loading"><Spinner /></span>
-    {/await}
-    <div class="entities-section">
-      <div class="from-entity">
-        <h2>From</h2>
-        {#key from}
-          <TaskEntity
-            entity={from}
-            {matchedTitles}
-          />
-        {/key}
-      </div>
-      {#if areBothInvEntities}
-        <button
-          class="swap"
-          on:click={exchangeFromTo}
-          title={I18n('swap from and to entities')}
-        >
-          {@html icon('exchange')}
-        </button>
-      {/if}
-      <div class="to-entity">
-        <h2>To</h2>
-        {#key to}
-          <TaskEntity
-            entity={to}
-            {matchedTitles}
-          />
-        {/key}
-      </div>
-    </div>
-    {#if isMerged}
-      <div class="error-wrapper">
-        <pre>{JSON.stringify(task, null, 2)}</pre>
-      </div>
-    {/if}
-    <TaskControls
+    <MergeLayout
       {task}
-      {from}
-      {to}
-      {flash}
-      on:next={nextTask}
+      {entitiesType}
+      {type}
+      on:next={showNextTask}
     />
   {:else}
     <NoTask />
   {/if}
   <Flash bind:state={flash} />
 {/await}
-<style lang="scss">
-  @import "#general/scss/utils";
-  .entities-section{
-    @include display-flex(row, flex-start, flex-start);
-    background-color: #ddd;
-  }
-  .from-entity{
-    min-height: 100vh;
-    padding-inline-start: 1em;
-    flex: 1 0 0;
-  }
-  .to-entity{
-    min-height: 100vh;
-    background-color: $light-grey;
-    padding-inline-start: 1em;
-    flex: 1 0 0;
-  }
-  h2{
-    @include display-flex(row, null, center);
-    @include sans-serif;
-    font-size: 1.2rem;
-    margin: 0;
-    padding-block-start: 0.3em;
-  }
-  .error-wrapper{
-    background-color: $light-grey;
-    max-width: 40em;
-    margin: 1em auto;
-    padding: 1em;
-  }
-  .swap{
-    position: relative;
-    inset-inline-start: 1.3em;
-    inset-block-start: 30vh;
-    background-color: white;
-    padding: 0.5em;
-    border-radius: 50%;
-  }
-  .loading{
-    position: absolute;
-    margin: 0 auto;
-    padding-block-start: 0.5em;
-    width: 100%;
-  }
-</style>

--- a/app/modules/tasks/components/task_layout.svelte
+++ b/app/modules/tasks/components/task_layout.svelte
@@ -8,6 +8,7 @@
   import DeleteLayout from './delete_layout.svelte'
   import MergeLayout from './merge_layout.svelte'
   import NoTask from './no_task.svelte'
+  import TaskBreadcrumb from './task_breadcrumb.svelte'
 
   export let taskId: TaskId
   export let entitiesType, type
@@ -49,7 +50,13 @@
     nextTaskOffset = 0
     task = null
   }
+  $: taskId = task?._id
 </script>
+<TaskBreadcrumb
+  {entitiesType}
+  {type}
+  {taskId}
+/>
 {#await waitForTask then}
   {#if task}
     {#if type === 'delete'}

--- a/app/modules/tasks/components/task_layout.svelte
+++ b/app/modules/tasks/components/task_layout.svelte
@@ -5,6 +5,7 @@
   import preq from '#app/lib/preq'
   import type { TaskId } from '#server/types/task'
   import { getNextTask } from '#tasks/lib/get_next_task.ts'
+  import DeleteLayout from './delete_layout.svelte'
   import MergeLayout from './merge_layout.svelte'
   import NoTask from './no_task.svelte'
 
@@ -51,12 +52,21 @@
 </script>
 {#await waitForTask then}
   {#if task}
-    <MergeLayout
-      {task}
-      {entitiesType}
-      {type}
-      on:next={showNextTask}
-    />
+    {#if type === 'delete'}
+      <DeleteLayout
+        {task}
+        {entitiesType}
+        {type}
+        on:next={showNextTask}
+      />
+    {:else}
+      <MergeLayout
+        {task}
+        {entitiesType}
+        {type}
+        on:next={showNextTask}
+      />
+    {/if}
   {:else}
     <NoTask />
   {/if}

--- a/app/modules/tasks/tasks.ts
+++ b/app/modules/tasks/tasks.ts
@@ -6,6 +6,7 @@ export default {
       appRoutes: {
         'tasks(/)': 'showTasksDashboard',
         'tasks/none(/)': 'showTasksDashboard',
+        'tasks/delete/(:entitiesType)(/)': 'showDeleteTask',
         'tasks/merge/(:entitiesType)(/)': 'showMergeTask',
         'tasks/deduplicate/(:entitiesType)(/)': 'showDeduplicateTask',
         'tasks/:id(/)': 'showTask',

--- a/app/modules/tasks/tasks.ts
+++ b/app/modules/tasks/tasks.ts
@@ -5,11 +5,9 @@ export default {
     const Router = Marionette.AppRouter.extend({
       appRoutes: {
         'tasks(/)': 'showTasksDashboard',
-        'tasks/merge(/)': 'showTasksDashboard',
-        'tasks/deduplicate(/)': 'showTasksDashboard',
         'tasks/none(/)': 'showTasksDashboard',
-        'tasks/merge/:entitiesType(/)': 'showMergeTask',
-        'tasks/deduplicate/:entitiesType(/)': 'showDeduplicateTask',
+        'tasks/merge/(:entitiesType)(/)': 'showMergeTask',
+        'tasks/deduplicate/(:entitiesType)(/)': 'showDeduplicateTask',
         'tasks/:id(/)': 'showTask',
       },
     })
@@ -19,15 +17,13 @@ export default {
 }
 
 const controller = {
-  showMergeTask (entitiesType) { controller.showTask(null, 'merge', entitiesType) },
-  showDeduplicateTask (entitiesType) { controller.showTask(null, 'deduplicate', entitiesType) },
-  showTask (taskId, type, entitiesType) {
-    const singularEntitiesType = entitiesType?.slice(0, -1)
+  showDeleteTask (entitiesType) { showLayout({ type: 'delete', entitiesType }) },
+  showMergeTask (entitiesType) { showLayout({ type: 'merge', entitiesType }) },
+  showDeduplicateTask (entitiesType) { showLayout({ type: 'deduplicate', entitiesType }) },
+  showTask (taskId) {
     if (app.request('require:dataadmin:access', 'tasks')) {
       return showLayout({
         taskId,
-        entitiesType: singularEntitiesType,
-        type,
       })
     }
   },
@@ -40,6 +36,10 @@ const controller = {
 }
 
 const showLayout = async params => {
+  const { entitiesType } = params
+  if (entitiesType) {
+    params.entitiesType = entitiesType.slice(0, -1)
+  }
   const { default: TaskLayout } = await import('./components/task_layout.svelte')
   app.layout.showChildComponent('main', TaskLayout, {
     props: params,

--- a/app/modules/tasks/tasks.ts
+++ b/app/modules/tasks/tasks.ts
@@ -5,11 +5,11 @@ export default {
     const Router = Marionette.AppRouter.extend({
       appRoutes: {
         'tasks(/)': 'showTasksDashboard',
-        'tasks/none(/)': 'showTasksDashboard',
         'tasks/delete/(:entitiesType)(/)': 'showDeleteTask',
         'tasks/merge/(:entitiesType)(/)': 'showMergeTask',
         'tasks/deduplicate/(:entitiesType)(/)': 'showDeduplicateTask',
-        'tasks/:id(/)': 'showTask',
+        'tasks/none(/)': 'showNoTask',
+        'tasks(/)(:id)(/)': 'showTask',
       },
     })
 
@@ -23,10 +23,12 @@ const controller = {
   showDeduplicateTask (entitiesType) { showLayout({ type: 'deduplicate', entitiesType }) },
   showTask (taskId) {
     if (app.request('require:dataadmin:access', 'tasks')) {
-      return showLayout({
-        taskId,
-      })
+      return showLayout({ taskId })
     }
+  },
+  async showNoTask () {
+    const { default: NoTask } = await import('./components/no_task.svelte')
+    app.layout.showChildComponent('main', NoTask)
   },
   async showTasksDashboard () {
     if (app.request('require:dataadmin:access', 'tasks')) {


### PR DESCRIPTION
This PR add a new type of tasks ('delete') with a dedicated interface.

Goes with server side PR [#790](https://github.com/inventaire/inventaire/pull/790)

This PR also relies on the work done in #514 and #516.

It also adds a breadcrumb to ease navigation between all tasks types and entitiesTypes.

Should be merged after #516 