### PR TITLE
Landing map

### DIFF
--- a/app/api/items.ts
+++ b/app/api/items.ts
@@ -40,6 +40,10 @@ export default {
     return action('recent-public', { limit, lang, 'assert-image': assertImage })
   },
 
+  byBbox (bbox, limit, lang) {
+    return action('by-bbox', { bbox, limit, lang })
+  },
+
   nearby (limit, offset, range = 50) { return action('nearby', { limit, offset, range }) },
 
   inventoryView (params) { return action('inventory-view', params) },

--- a/app/modules/inventory/components/inventory_browser.svelte
+++ b/app/modules/inventory/components/inventory_browser.svelte
@@ -28,6 +28,7 @@
   export let groupId: GroupId = null
   export let shelfId: ShelfId = null
   export let itemsShelvesByIds = null
+  export let frozenDisplay = null
 
   const itemsSearchFilters: ItemsSearchFilters = { ownerId, groupId, shelfId }
   setContext('items-search-filters', itemsSearchFilters)
@@ -83,8 +84,8 @@
     bind:textFilterItemsIds
     {intersectionWorkUris}
     {inventoryDisplay}
+    {frozenDisplay}
   />
-
   {#await waitForInventoryData}
     <div class="spinner-wrap">
       <Spinner center={true} />
@@ -92,7 +93,7 @@
   {:then}
     {#if pagination}
       <PaginatedItems
-        display={$inventoryDisplay}
+        display={frozenDisplay || $inventoryDisplay}
         {itemsIds}
         {itemsShelvesByIds}
         {shelfId}

--- a/app/modules/inventory/components/inventory_browser_controls.svelte
+++ b/app/modules/inventory/components/inventory_browser_controls.svelte
@@ -8,7 +8,7 @@
   import InventoryBrowserTextFilter from '#inventory/components/inventory_browser_text_filter.svelte'
   import { I18n, i18n } from '#user/lib/i18n'
 
-  export let waitForInventoryData, facetsSelectors, facetsSelectedValues, intersectionWorkUris, textFilterItemsIds, inventoryDisplay
+  export let waitForInventoryData, facetsSelectors, facetsSelectedValues, intersectionWorkUris, textFilterItemsIds, inventoryDisplay, frozenDisplay
 
   const displayOptions = [
     { value: 'cascade', icon: 'th-large', text: I18n('cascade') },
@@ -70,14 +70,16 @@
           </div>
         {/await}
       </div>
-      <div class="display-controls">
-        <SelectDropdown
-          bind:value={$inventoryDisplay}
-          options={displayOptions}
-          buttonLabel={I18n('display_mode')}
-          hideCurrentlySelectedOption={true}
-        />
-      </div>
+      {#if !frozenDisplay}
+        <div class="display-controls">
+          <SelectDropdown
+            bind:value={$inventoryDisplay}
+            options={displayOptions}
+            buttonLabel={I18n('display_mode')}
+            hideCurrentlySelectedOption={true}
+          />
+        </div>
+      {/if}
     {/if}
   </div>
 

--- a/app/modules/inventory/components/inventory_browser_modal.svelte
+++ b/app/modules/inventory/components/inventory_browser_modal.svelte
@@ -5,13 +5,14 @@
   import InventoryBrowser from '#inventory/components/inventory_browser.svelte'
   import { getInventoryView } from '#inventory/components/lib/inventory_browser_helpers'
   import { i18n } from '#user/lib/i18n'
+  import UserInfobox from '#users/components/user_infobox.svelte'
 
   export let user
   export let group
   export let isMainUser = false
   export let showModal = false
 
-  let itemsDataPromise, name, linkUrl
+  let itemsDataPromise, name, linkUrl, picture
 
   function closeModal () {
     showModal = false
@@ -25,8 +26,8 @@
   function updateModalData ({ user, group }) {
     if (!(user || group)) return
     if (user) {
-      itemsDataPromise = getInventoryView('user', user)
-      name = user.username
+      itemsDataPromise = getInventoryView('user', user);
+      ({ username: name, picture } = user)
       linkUrl = `/users/${name}`
     } else if (group) {
       itemsDataPromise = getInventoryView('group', group)
@@ -43,12 +44,24 @@
         <h2>
           {i18n('Public books')}
         </h2>
-        <Link
-          url={linkUrl}
-          text={name}
-          classNames="link"
-        />
       </div>
+      {#key name}
+        {#if user}
+          <UserInfobox
+            {linkUrl}
+            label={i18n('From user')}
+            {name}
+            {picture}
+          />
+        {:else if group}
+          <span class="label">{i18n('From group')}</span>
+          <Link
+            url={linkUrl}
+            text={name}
+            classNames="link"
+          />
+        {/if}
+      {/key}
       <InventoryBrowser
         {itemsDataPromise}
         ownerId={user?._id}
@@ -65,6 +78,7 @@
   .modal-wrapper{
     :global(.modal-inner){
       min-width: 80vw;
+      margin: 0 0.5em
     }
     .header{
       @include display-flex(column, center);
@@ -74,8 +88,16 @@
       margin-block-start: 1em;
       font-size: 1.4em;
     }
+    .label{
+      color: $label-grey;
+      display: block;
+    }
     :global(.link){
-      font-size: 1.2em;
+      display: block;
+      padding: 0.5em;
+      font-weight: bold;
+      @include radius;
+      @include bg-hover($light-grey);
     }
   }
 </style>

--- a/app/modules/inventory/components/inventory_browser_modal.svelte
+++ b/app/modules/inventory/components/inventory_browser_modal.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { onChange } from '#app/lib/svelte/svelte'
+  import Modal from '#components/modal.svelte'
+  import InventoryBrowser from '#inventory/components/inventory_browser.svelte'
+  import { getInventoryView } from '#inventory/components/lib/inventory_browser_helpers'
+
+  export let user
+  export let group
+  export let isMainUser = false
+  export let showModal = false
+
+  let itemsDataPromise
+
+  function closeModal () {
+    showModal = false
+    user = null
+    group = null
+  }
+
+  $: onChange(user, () => updateInventoryViewPromise({ user }))
+  $: onChange(group, () => updateInventoryViewPromise({ group }))
+
+  function updateInventoryViewPromise ({ user, group }) {
+    if (!(user || group)) return
+    if (user) {
+      itemsDataPromise = getInventoryView('user', user)
+    } else if (group) {
+      itemsDataPromise = getInventoryView('group', group)
+    }
+  }
+</script>
+
+{#if user || group}
+  <Modal size="large" on:closeModal={closeModal}>
+    <InventoryBrowser
+      {itemsDataPromise}
+      ownerId={user?._id}
+      groupId={group?._id}
+      {isMainUser}
+    />
+  </Modal>
+{/if}

--- a/app/modules/inventory/components/inventory_browser_modal.svelte
+++ b/app/modules/inventory/components/inventory_browser_modal.svelte
@@ -54,6 +54,7 @@
         ownerId={user?._id}
         groupId={group?._id}
         {isMainUser}
+        frozenDisplay="table"
       />
     </Modal>
   </div>

--- a/app/modules/inventory/components/inventory_browser_modal.svelte
+++ b/app/modules/inventory/components/inventory_browser_modal.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
+  import Link from '#app/lib/components/link.svelte'
   import { onChange } from '#app/lib/svelte/svelte'
   import Modal from '#components/modal.svelte'
   import InventoryBrowser from '#inventory/components/inventory_browser.svelte'
   import { getInventoryView } from '#inventory/components/lib/inventory_browser_helpers'
+  import { i18n } from '#user/lib/i18n'
 
   export let user
   export let group
   export let isMainUser = false
   export let showModal = false
 
-  let itemsDataPromise
+  let itemsDataPromise, name, linkUrl
 
   function closeModal () {
     showModal = false
@@ -17,26 +19,62 @@
     group = null
   }
 
-  $: onChange(user, () => updateInventoryViewPromise({ user }))
-  $: onChange(group, () => updateInventoryViewPromise({ group }))
+  $: onChange(user, () => updateModalData({ user }))
+  $: onChange(group, () => updateModalData({ group }))
 
-  function updateInventoryViewPromise ({ user, group }) {
+  function updateModalData ({ user, group }) {
     if (!(user || group)) return
     if (user) {
       itemsDataPromise = getInventoryView('user', user)
+      name = user.username
+      linkUrl = `/users/${name}`
     } else if (group) {
       itemsDataPromise = getInventoryView('group', group)
+      name = group.name
+      linkUrl = `/groups/${group.slug}`
     }
   }
 </script>
 
 {#if user || group}
-  <Modal size="large" on:closeModal={closeModal}>
-    <InventoryBrowser
-      {itemsDataPromise}
-      ownerId={user?._id}
-      groupId={group?._id}
-      {isMainUser}
-    />
-  </Modal>
+  <div class="modal-wrapper">
+    <Modal size="large" on:closeModal={closeModal}>
+      <div class="header">
+        <h2>
+          {i18n('Public books')}
+        </h2>
+        <Link
+          url={linkUrl}
+          text={name}
+          classNames="link"
+        />
+      </div>
+      <InventoryBrowser
+        {itemsDataPromise}
+        ownerId={user?._id}
+        groupId={group?._id}
+        {isMainUser}
+      />
+    </Modal>
+  </div>
 {/if}
+
+<style lang="scss">
+  @import "#general/scss/utils";
+  .modal-wrapper{
+    :global(.modal-inner){
+      min-width: 80vw;
+    }
+    .header{
+      @include display-flex(column, center);
+    }
+    h2{
+      font-weight: bold;
+      margin-block-start: 1em;
+      font-size: 1.4em;
+    }
+    :global(.link){
+      font-size: 1.2em;
+    }
+  }
+</style>

--- a/app/modules/inventory/lib/queries.ts
+++ b/app/modules/inventory/lib/queries.ts
@@ -84,6 +84,13 @@ const getRecentPublic = async params => {
   return res
 }
 
+const getByBbox = async params => {
+  const { bbox, limit, lang } = params
+  const res = await preq.get(API.items.byBbox(bbox, limit, lang))
+  updateItemsParams(res, params)
+  return res
+}
+
 export async function getUserItems (params) {
   const { userId } = params
   return makeRequestAlt(params, 'byUsers', [ userId ])
@@ -117,6 +124,7 @@ export default app => app.reqres.setHandlers({
   'items:getNearbyItems': getNearbyItems,
   'items:getLastPublic': getLastPublic,
   'items:getRecentPublic': getRecentPublic,
+  'items:getByBbox': getByBbox,
   'items:getNetworkItems': getNetworkItems,
   'items:getByUserIdAndEntities': getByUserIdAndEntities,
 

--- a/app/modules/listings/components/listing_info_box.svelte
+++ b/app/modules/listings/components/listing_info_box.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import { imgSrc } from '#app/lib/handlebars_helpers/images'
   import { icon } from '#app/lib/icons'
   import { onChange } from '#app/lib/svelte/svelte'
-  import { loadInternalLink } from '#app/lib/utils'
   import type { SerializedUser } from '#app/modules/users/lib/users'
   import Dropdown from '#components/dropdown.svelte'
   import Modal from '#components/modal.svelte'
@@ -10,6 +8,7 @@
   import ListingEditor from '#listings/components/listing_editor.svelte'
   import type { Listing } from '#server/types/listing'
   import { i18n } from '#user/lib/i18n'
+  import UserInfobox from '#users/components/user_infobox.svelte'
 
   export let listing: Listing
   export let isEditable: boolean
@@ -19,7 +18,7 @@
 
   let visibilitySummary, visibilitySummaryIcon, visibilitySummaryLabel, showListEditorModal
 
-  const { username, picture: userPicture, listingsPathname: userListingsPathname } = creator
+  const { username, picture, listingsPathname: userListingsPathname } = creator
 
   const updateVisibilitySummary = () => {
     visibility = listing.visibility
@@ -64,17 +63,13 @@
     {/if}
   </div>
   <div class="creator-row">
-    <div class="creator-info">
-      <span class="label">{i18n('List creator')}</span>
-      <a
-        href={userListingsPathname}
-        title={i18n('see_all_listings_by_user', { username })}
-        on:click={loadInternalLink}
-      >
-        <img src={imgSrc(userPicture, 32)} alt="" loading="lazy" />
-        <span class="username">{username}</span>
-      </a>
-    </div>
+    <UserInfobox
+      linkUrl={userListingsPathname}
+      linkTitle={i18n('see_all_listings_by_user', { username })}
+      label={i18n('List creator')}
+      name={username}
+      {picture}
+    />
     {#if visibility}
       <div class="visibility">
         <span class="label">{i18n('Visible by')}</span>
@@ -120,23 +115,6 @@
   .creator-row{
     margin-block-start: 1em;
     @include display-flex(row, center, space-between);
-  }
-  .label{
-    color: $label-grey;
-    display: block;
-  }
-  .creator-info{
-    a{
-      display: block;
-      padding: 0.3em 0;
-      @include radius;
-      @include bg-hover($light-grey);
-    }
-  }
-  .username{
-    font-weight: bold;
-    @include sans-serif;
-    margin-inline-start: 0.2em;
   }
   [slot="button-inner"]{
     @include tiny-button($grey);

--- a/app/modules/map/components/zoom_in_to_display_more.svelte
+++ b/app/modules/map/components/zoom_in_to_display_more.svelte
@@ -1,0 +1,33 @@
+<script>
+  import { onChange } from '#app/lib/svelte/svelte'
+  import { isMapTooZoomedOut } from '#map/lib/map'
+  import { i18n } from '#user/lib/i18n'
+
+  export let mapZoom
+  export let displayedElementsCount
+
+  export let zoomInToDisplayMore = false
+  function updateZoomStatus () {
+    zoomInToDisplayMore = isMapTooZoomedOut(mapZoom, displayedElementsCount)
+  }
+
+  $: onChange(mapZoom, updateZoomStatus)
+</script>
+
+{#if zoomInToDisplayMore}
+  <div class="zoom-in-overlay">
+    <p>{i18n('Zoom-in to display more')}</p>
+  </div>
+{/if}
+
+<style lang="scss">
+  @import "#general/scss/utils";
+
+  .zoom-in-overlay{
+    background-color: rgba($dark-grey, 0.5);
+    @include position(absolute, 0, 0, 0, 0);
+    // Above map but below controls
+    z-index: 400;
+    @include display-flex(column, center, center);
+  }
+</style>

--- a/app/modules/map/lib/map.ts
+++ b/app/modules/map/lib/map.ts
@@ -36,3 +36,9 @@ export function uniqBounds (bounds) {
 
 const stringifyBound = bound => JSON.stringify(bound)
 const parseStringifiedBound = stringifiedBound => JSON.parse(stringifiedBound)
+
+export function isMapTooZoomedOut (mapZoom, displayedElementsCount) {
+  if (mapZoom >= 10) return false
+  if (!displayedElementsCount) return false
+  return displayedElementsCount > 20
+}

--- a/app/modules/tasks/components/task_info.svelte
+++ b/app/modules/tasks/components/task_info.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import Link from '#app/lib/components/link.svelte'
-  import { imgSrc } from '#app/lib/handlebars_helpers/images'
-  import { loadInternalLink } from '#app/lib/utils'
   import Spinner from '#components/spinner.svelte'
-  import { i18n, I18n } from '#user/lib/i18n'
+  import { I18n } from '#user/lib/i18n'
+  import UserInfobox from '#users/components/user_infobox.svelte'
   import { getUsersByIds } from '#users/users_data'
 
   export let task
@@ -18,18 +17,16 @@
 {#await waitingForUsers}
   <Spinner center={true} />
 {:then}
-  <strong>{i18n('reporters')}: </strong>
+  <strong>{I18n('reporters')}</strong>
   <ul>
     {#each reporters as reporter}
-      <li class="creator-info">
-        <a
-          href={`/users/${reporter._id}/contributions`}
-          title={I18n('contributions_by', reporter)}
-          on:click={loadInternalLink}
-        >
-          <img src={imgSrc(reporter.picture, 32)} alt="" loading="lazy" />
-          <span class="username">{reporter.username}</span>
-        </a>
+      <li>
+        <UserInfobox
+          name={reporter.username}
+          picture={reporter.picture}
+          linkUrl={`/users/${reporter._id}/contributions`}
+          linkTitle={I18n('contributions_by', reporter)}
+        />
       </li>
     {/each}
   </ul>
@@ -37,28 +34,10 @@
 
 {#if clue}
   <li>
-    <strong>{i18n('clue')}: </strong>
+    <strong>{I18n('clue')}</strong>
     <Link
       url={`/entity/isbn:${clue}`}
       text={clue}
     />
   </li>
 {/if}
-
-<style lang="scss">
-  @import "#general/scss/utils";
-  .creator-info{
-    a{
-      display: block;
-      padding: 0.3em 0;
-      @include radius;
-      @include bg-hover($light-grey);
-    }
-  }
-  .username{
-    font-weight: normal;
-    @include sans-serif;
-    margin-inline-start: 0.2em;
-    margin-inline-end: 0.5em;
-  }
-</style>

--- a/app/modules/user/lib/solve_lang.ts
+++ b/app/modules/user/lib/solve_lang.ts
@@ -16,7 +16,7 @@ export function solveLang (userLanguage) {
 }
 
 // Adapted from: https://github.com/maxogden/browser-locale/blob/master/index.js
-const getBrowserLocalLang = function () {
+export const getBrowserLocalLang = function () {
   // Latest versions of Chrome and Firefox set this correctly
   if (navigator.languages && navigator.languages.length) return navigator.languages[0]
   // IE only

--- a/app/modules/users/components/lib/public_users_nav_helpers.ts
+++ b/app/modules/users/components/lib/public_users_nav_helpers.ts
@@ -24,7 +24,7 @@ export async function getGroupsByPosition ({ bbox }) {
   return groupsById
 }
 
-async function getDocsByPosition (name, bbox) {
+export async function getDocsByPosition (name, bbox) {
   const { [name]: docs } = await preq.get(API[name].searchByPosition(bbox))
   return docs
 }

--- a/app/modules/users/components/public_users_nav.svelte
+++ b/app/modules/users/components/public_users_nav.svelte
@@ -9,7 +9,8 @@
   import Marker from '#map/components/marker.svelte'
   import PositionRequired from '#map/components/position_required.svelte'
   import UserMarker from '#map/components/user_marker.svelte'
-  import { getBbox } from '#map/lib/map'
+  import ZoomInToDisplayMore from '#map/components/zoom_in_to_display_more.svelte'
+  import { getBbox, isMapTooZoomedOut } from '#map/lib/map'
   import { i18n, I18n } from '#user/lib/i18n'
   import { user } from '#user/user_store'
   import { getGroupsByPosition, getUsersByPosition } from '#users/components/lib/public_users_nav_helpers'
@@ -25,6 +26,7 @@
 
   let usersById = {}, groupsById = {}
   let map, bbox, mapViewLatLng, mapZoom, flash
+  let zoomInToDisplayMore, displayedElementsCount
 
   const getByPosition = async (name, bbox) => {
     try {
@@ -43,7 +45,8 @@
   let waitForUsers, waitForGroups
   function fetchAndShowUsersAndGroupsOnMap () {
     if (!map) return
-    if (mapIsTooZoomedOut()) return
+    displayedElementsCount = usersInBounds.length + groupsInBounds.length
+    if (isMapTooZoomedOut(mapZoom, displayedElementsCount)) return
     bbox = getBbox(map)
     if (!bbox) return
 
@@ -66,23 +69,11 @@
     }
   }
 
-  function mapIsTooZoomedOut () {
-    if (mapZoom >= 10) return false
-    if (!usersInBounds || !groupsInBounds) return false
-    const displayedElementsCount = usersInBounds.length + groupsInBounds.length
-    return displayedElementsCount > 20
-  }
-
-  let zoomInToDisplayMore = false
-  function updateZoomStatus () {
-    zoomInToDisplayMore = mapIsTooZoomedOut()
-  }
-
   let usersInBounds, groupsInBounds
 
   $: onChange(map, fetchAndShowUsersAndGroupsOnMap)
   $: onChange($user.position, onMainUserPositionChange)
-  $: onChange(mapZoom, usersInBounds, groupsInBounds, updateZoomStatus)
+  $: onChange(mapZoom, usersInBounds, groupsInBounds)
 
   let selectedUser, selectedGroup
   function onSelectUser (e) {
@@ -168,12 +159,12 @@
               </Marker>
             {/each}
           {/if}
+          <ZoomInToDisplayMore
+            {mapZoom}
+            {displayedElementsCount}
+            bind:zoomInToDisplayMore
+          />
 
-          {#if zoomInToDisplayMore}
-            <div class="zoom-in-overlay">
-              <p>{i18n('Zoom-in to display more')}</p>
-            </div>
-          {/if}
         </LeafletMap>
       {/if}
     </div>
@@ -245,14 +236,6 @@
       line-height: 0;
       border-end-end-radius: $global-radius;
     }
-  }
-
-  .zoom-in-overlay{
-    background-color: rgba($dark-grey, 0.5);
-    @include position(absolute, 0, 0, 0, 0);
-    // Above map but below controls
-    z-index: 400;
-    @include display-flex(column, center, center);
   }
 
   /* Small screens */

--- a/app/modules/welcome/components/public_map.svelte
+++ b/app/modules/welcome/components/public_map.svelte
@@ -14,7 +14,8 @@
   import { getBrowserLocalLang } from '#user/lib/solve_lang'
   import { getDocsByPosition } from '#users/components/lib/public_users_nav_helpers'
 
-  let items = [], users = [], groups = [], selectedUser, selectedGroup
+  export let items = []
+  let users = [], groups = [], selectedUser, selectedGroup
 
   // Arbitrary position (Lyon, France),
   // to not ask to geolocate as soon as landing on the page.

--- a/app/modules/welcome/components/public_map.svelte
+++ b/app/modules/welcome/components/public_map.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import app from '#app/app'
+  import Flash from '#app/lib/components/flash.svelte'
+  import { onChange } from '#app/lib/svelte/svelte'
+  import Spinner from '#components/spinner.svelte'
+  import InventoryBrowserModal from '#inventory/components/inventory_browser_modal.svelte'
+  import GroupMarker from '#map/components/group_marker.svelte'
+  import LeafletMap from '#map/components/leaflet_map.svelte'
+  import Marker from '#map/components/marker.svelte'
+  import UserMarker from '#map/components/user_marker.svelte'
+  import ZoomInToDisplayMore from '#map/components/zoom_in_to_display_more.svelte'
+  import { getBbox, isMapTooZoomedOut } from '#map/lib/map'
+  import { i18n } from '#user/lib/i18n'
+  import { getBrowserLocalLang } from '#user/lib/solve_lang'
+  import { getDocsByPosition } from '#users/components/lib/public_users_nav_helpers'
+
+  let items = [], users = [], groups = [], selectedUser, selectedGroup
+
+  // Arbitrary position (Lyon, France),
+  // to not ask to geolocate as soon as landing on the page.
+  const landingPageMapPosition = [ 45.744, 4.821 ]
+  let map, mapZoom = 13, bbox, flash, displayedElementsCount
+
+  const waitingForUsers = fetchItemsUsersAndGroups()
+
+  async function fetchItemsUsersAndGroups () {
+    if (!map) return
+    displayedElementsCount = users.length + groups.length
+
+    if (isMapTooZoomedOut(mapZoom, displayedElementsCount)) return
+    bbox = getBbox(map)
+    if (!bbox) return
+
+    const lang = getBrowserLocalLang();
+    ([ { users, items }, groups ] = await Promise.all([
+      app.request('items:getByBbox', { items, bbox, lang })
+        .catch(err => {
+          if (err.message !== 'no items found') flash = err
+        }),
+      getDocsByPosition('groups', bbox),
+    ]))
+    if (items.length === 0) {
+      flash = {
+        type: 'warning',
+        message: i18n('No visible books in this area'),
+      }
+    } else { flash = null }
+  }
+
+  let zoomInToDisplayMore = false
+  function updateZoomStatus () {
+    zoomInToDisplayMore = isMapTooZoomedOut()
+  }
+
+  $: onChange(map, fetchItemsUsersAndGroups)
+  $: onChange(mapZoom, updateZoomStatus)
+</script>
+
+<section>
+  <h3>{i18n('Users and groups in the area')}</h3>
+  <div id="mapContainer">
+    <LeafletMap
+      view={landingPageMapPosition}
+      bind:map
+      cluster={true}
+      bind:zoom={mapZoom}
+      on:moveend={fetchItemsUsersAndGroups}
+      showLocationSearchInput={true}
+      showFindPositionFromGeolocation={true}
+    >
+      {#await waitingForUsers}
+        <Spinner />
+      {:then}
+        {#if users && !zoomInToDisplayMore}
+          {#each users as user (user._id)}
+            <Marker latLng={user.position} standalone={user.isMainUser}>
+              <UserMarker
+                doc={user}
+                on:select={() => selectedUser = user}
+              />
+            </Marker>
+          {/each}
+        {/if}
+
+        {#if groups && !zoomInToDisplayMore}
+          {#each groups as group (group._id)}
+            <Marker latLng={group.position}>
+              <GroupMarker
+                doc={group}
+                on:select={() => selectedGroup = group}
+              />
+            </Marker>
+          {/each}
+        {/if}
+
+        <ZoomInToDisplayMore
+          {mapZoom}
+          {displayedElementsCount}
+        />
+      {/await}
+    </LeafletMap>
+  </div>
+  <Flash state={flash} />
+</section>
+
+<InventoryBrowserModal
+  user={selectedUser}
+  group={selectedGroup}
+/>
+
+<style lang="scss">
+  @import "#welcome/scss/welcome_layout_commons";
+
+  section{
+    background-color: $off-white;
+    overflow: hidden;
+    max-height: 100vh;
+    overflow-y: hidden;
+    position: relative;
+  }
+
+  #mapContainer{
+    height: 50vh;
+    z-index: 0;
+    @include display-flex(row, center, center);
+    background-color: $off-white;
+    position: relative;
+    :global(.items-count), :global(.group-admin-badge), :global(.members-count){
+      position: absolute;
+      background-color: white;
+      color: $dark-grey;
+      line-height: 0;
+      min-width: 1em;
+    }
+    :global(.items-count), :global(.members-count){
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      text-align: center;
+      padding: 0.2em 0;
+      border-end-start-radius: $global-radius;
+      @include transition;
+    }
+    :global(.group-admin-badge){
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      // Somehow centers the icon vertically
+      line-height: 0;
+      border-end-end-radius: $global-radius;
+    }
+  }
+
+  /* Large screens */
+  @media screen and (width >= $smaller-screen){
+    section{
+      padding: 0 1em;
+    }
+  }
+  // Do not override item_card style
+  h3:not(.title){
+    text-align: center;
+    font-size: 1.2em;
+    margin-block-start: 0.5em;
+  }
+</style>

--- a/app/modules/welcome/components/some_public_books.svelte
+++ b/app/modules/welcome/components/some_public_books.svelte
@@ -7,6 +7,8 @@
   import ItemsTable from '#inventory/components/items_table.svelte'
   import { I18n } from '#user/lib/i18n'
 
+  export let items = []
+
   const params = {
     lang: app.user.lang,
     assertImage: true,
@@ -18,26 +20,37 @@
       if (err.message !== 'no item found') throw err
     })
 </script>
-
-{#await waiting}
-  <Spinner />
-{:then}
-  {#if isNonEmptyArray(params.items)}
-    <section>
-      <h3>{I18n('some of the last books listed')}</h3>
-      {#await waiting}
-        <Spinner center={true} />
-      {:then}
-        {#if $screen.isSmallerThan('$smaller-screen')}
-          <ItemsTable items={params.items} {waiting} haveSeveralOwners={true} />
-        {:else}
-          <ItemsCascade items={params.items} {waiting} />
-        {/if}
-      {/await}
-      <div class="fade-out" />
-    </section>
-  {/if}
-{/await}
+{#if isNonEmptyArray(items)}
+  <section>
+    <h3>{I18n('some books in this area')}</h3>
+    {#if $screen.isSmallerThan('$smaller-screen')}
+      <ItemsTable {items} haveSeveralOwners={true} />
+    {:else}
+      <ItemsCascade {items} />
+    {/if}
+    <div class="fade-out" />
+  </section>
+{:else}
+  {#await waiting}
+    <Spinner />
+  {:then}
+    {#if isNonEmptyArray(params.items)}
+      <section>
+        <h3>{I18n('some of the last books listed')}</h3>
+        {#await waiting}
+          <Spinner center={true} />
+        {:then}
+          {#if $screen.isSmallerThan('$smaller-screen')}
+            <ItemsTable items={params.items} {waiting} haveSeveralOwners={true} />
+          {:else}
+            <ItemsCascade items={params.items} {waiting} />
+          {/if}
+        {/await}
+        <div class="fade-out" />
+      </section>
+    {/if}
+  {/await}
+{/if}
 
 <style lang="scss">
   @import "#welcome/scss/welcome_layout_commons";

--- a/app/modules/welcome/components/welcome_layout.svelte
+++ b/app/modules/welcome/components/welcome_layout.svelte
@@ -3,12 +3,14 @@
   import LandingScreen from '#welcome/components/landing_screen.svelte'
   import PublicMap from '#welcome/components/public_map.svelte'
   import SomePublicBooks from '#welcome/components/some_public_books.svelte'
+
+  let items = []
 </script>
 
 <div class="welcome-layout">
   <LandingScreen />
-  <PublicMap />
-  <SomePublicBooks />
+  <PublicMap bind:items />
+  <SomePublicBooks {items} />
   <LandingPageFooter />
   <div class="background-cover" />
 </div>

--- a/app/modules/welcome/components/welcome_layout.svelte
+++ b/app/modules/welcome/components/welcome_layout.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import LandingPageFooter from '#welcome/components/landing_page_footer.svelte'
   import LandingScreen from '#welcome/components/landing_screen.svelte'
+  import PublicMap from '#welcome/components/public_map.svelte'
   import SomePublicBooks from '#welcome/components/some_public_books.svelte'
 </script>
 
 <div class="welcome-layout">
   <LandingScreen />
+  <PublicMap />
   <SomePublicBooks />
   <LandingPageFooter />
   <div class="background-cover" />


### PR DESCRIPTION
This PR allows the landing page to have a map of current users and groups.

Users on the map have a sample of their public group displayed below the map. If no items can be displayed, a list of recent items is displayed (aka the display before this PR).

When clicking on markers, the full list of the public items is shown in a modal (which is preferred compared to navigating to the group or user profile, in order to not extract from the map context).

Additionally to a nominatim finder, one may "geolocate" on the map.

Solves https://github.com/inventaire/inventaire-client/issues/295

TODO post decentralisation: put `landingPageMapPosition` in config