### PR TITLE
format infobox dates according to browser locale

### DIFF
--- a/app/modules/entities/components/layouts/claim_infobox.svelte
+++ b/app/modules/entities/components/layouts/claim_infobox.svelte
@@ -3,6 +3,7 @@
   import { isNonEmptyArray } from '#app/lib/boolean_tests'
   import { propertiesType } from '#entities/components/lib/claims_helpers'
   import { propertiesPerType } from '#entities/lib/editor/properties_per_type'
+  import { localizeDateString } from '#entities/lib/localize_date_string'
   import { I18n } from '#user/lib/i18n'
   import ClaimValue from './claim_value.svelte'
 
@@ -19,13 +20,16 @@
 
   // Known case: values = [ '1954-07-29', '1954' ]
   // Assumptions: longest date is more precice and more accurate than shorter one
-  const findLongestDate = values => [ max(values, v => v.length) ]
 
-  if (propertiesType[prop] === 'timeClaim' && values && values.length > 1) {
-    values = findLongestDate(values)
+  const findLongestValue = values => max(values, v => v.length)
+
+  let serializedValues = values
+  if (propertiesType[prop] === 'timeClaim' && values) {
+    const dateString = findLongestValue(values)
+    serializedValues = [ localizeDateString(dateString) ]
   }
 </script>
-{#if values && isNonEmptyArray(values)}
+{#if serializedValues && isNonEmptyArray(serializedValues)}
   <div class="claim">
     {#if !omitLabel}
       <span class="property">
@@ -33,12 +37,12 @@
       </span>
     {/if}
     <span class="values">
-      {#each values as value, i}
+      {#each serializedValues as value, i}
         <ClaimValue
           {value}
           {prop}
           entity={entitiesByUris[value]}
-        />{#if i !== values.length - 1},&nbsp;{/if}
+        />{#if i !== serializedValues.length - 1},&nbsp;{/if}
       {/each}
     </span>
   </div>

--- a/app/modules/entities/lib/localize_date_string.ts
+++ b/app/modules/entities/lib/localize_date_string.ts
@@ -5,9 +5,11 @@ export function localizeDateString (dateString) {
   const datePrecision = precisionByDatePartsCount[datePartsCount] || 'year'
   dateString = fillDateString(dateString, datePrecision)
   const date = new Date(dateString)
-
-  const preferredLocal = navigator.languages?.find(local => local.startsWith(`${app.user.lang}-`)) || undefined
-  return date.toLocaleDateString(preferredLocal, optionsDatesByPrecisions[datePrecision])
+  const userLang = app.user.lang
+  const preferredLocale = navigator.languages?.find(locale => locale.startsWith(`${userLang}-`)) || userLang
+  // undefined is letting the browser define its own locale
+  const resolvableLocale = isResolvableIntlLangageCode(preferredLocale) ? preferredLocale : undefined
+  return date.toLocaleDateString(resolvableLocale, optionsDatesByPrecisions[datePrecision])
 }
 
 const precisionByDatePartsCount = {
@@ -20,6 +22,15 @@ function fillDateString (dateString, datePrecision) {
   // The Date Object needs a defined day, even if a month precision will be displayed.
   // This adds a day placeholder when necessary
   return datePrecision === 'month' ? `${dateString}-01` : dateString
+}
+
+function isResolvableIntlLangageCode (lang: string) {
+  try {
+    return new Intl.DateTimeFormat(lang)
+  } catch (err) {
+    if (err.name !== 'RangeError') throw err
+    return false
+  }
 }
 
 const optionsDatesByPrecisions = {

--- a/app/modules/entities/lib/localize_date_string.ts
+++ b/app/modules/entities/lib/localize_date_string.ts
@@ -1,0 +1,38 @@
+import app from '#app/app'
+
+export function localizeDateString (dateString) {
+  const datePartsCount = dateString.replace(/^-/, '').split('-').length
+  const datePrecision = precisionByDatePartsCount[datePartsCount] || 'year'
+  dateString = fillDateString(dateString, datePrecision)
+  const date = new Date(dateString)
+
+  const preferredLocal = navigator.languages?.find(local => local.startsWith(`${app.user.lang}-`)) || undefined
+  return date.toLocaleDateString(preferredLocal, optionsDatesByPrecisions[datePrecision])
+}
+
+const precisionByDatePartsCount = {
+  1: 'year',
+  2: 'month',
+  3: 'day',
+}
+
+function fillDateString (dateString, datePrecision) {
+  // The Date Object needs a defined day, even if a month precision will be displayed.
+  // This adds a day placeholder when necessary
+  return datePrecision === 'month' ? `${dateString}-01` : dateString
+}
+
+const optionsDatesByPrecisions = {
+  year: {
+    year: 'numeric',
+  },
+  month: {
+    year: 'numeric',
+    month: 'long',
+  },
+  day: {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  },
+}


### PR DESCRIPTION
This PR should upgrade the date display to the browser's locale format.

For example, for a locale `en_US`, dates will be changed as: 

`2024` -> `2024`
`2024-03` -> `March 2024`
`2024-03-04` -> `March 4, 2024`

It uses `Date.prototype.toLocaleDateString()` under the hood, and tweak the month precision to display it accordingly.

Would be great to add `localizeDateString` to the editor too, but I haven't found an elegant way to do it, so let's say this is a first step.